### PR TITLE
[3.0] fix duplicate definition of capi_checksum256

### DIFF
--- a/libraries/eosiolib/core/eosio/crypto_ext.hpp
+++ b/libraries/eosiolib/core/eosio/crypto_ext.hpp
@@ -15,7 +15,7 @@ namespace eosio {
    namespace internal_use_do_not_use {
       extern "C" {
 
-         struct __attribute__((aligned (16))) capi_checksum256 { uint8_t hash[32]; };
+         struct __attribute__((aligned (16))) capi_checksum256_ext { uint8_t hash[32]; };
 
          __attribute__((eosio_wasm_import))
          int32_t alt_bn128_add( const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* result, uint32_t result_len);
@@ -40,7 +40,7 @@ namespace eosio {
       }
 
       static inline auto sha3_helper(const char* data, uint32_t length, bool keccak) {
-         internal_use_do_not_use::capi_checksum256 hash;
+         internal_use_do_not_use::capi_checksum256_ext hash;
          internal_use_do_not_use::sha3( data, length, (char*)&hash, sizeof(hash), keccak);
          eosio::checksum256 dg;
          eosio::datastream<uint8_t*> ds = {&hash.hash[0], sizeof(hash)};


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
`crypto_ext.hpp` defines  `capi_checksum256` for internal use. Unfortunately this conflicts with  `capi_checksum256` in `system.hpp`. The fix is to rename `capi_checksum256`  to `capi_checksum256_ext` in `crypto_ext.hpp`.
  
Resolve https://github.com/AntelopeIO/cdt/issues/29


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
