### PR TITLE
[docs] Clean up: EOSIO to Antelope

### DIFF
--- a/docs/03_command-reference/cdt-cc.md
+++ b/docs/03_command-reference/cdt-cc.md
@@ -2,7 +2,7 @@
 content_title: cdt-cc tool
 ---
 
-To manually compile the source code, use `cdt-cc` and `cdt-ld` as if it were __clang__ and __lld__. All the includes and options specific to EOSIO and CDT are baked in.
+To manually compile the source code, use `cdt-cc` and `cdt-ld` as if it were __clang__ and __lld__. All the includes and options specific to Antelope and CDT are baked in.
 
 ```
 USAGE: cdt-cc [options] <input file> ...

--- a/docs/03_command-reference/cdt-cpp.md
+++ b/docs/03_command-reference/cdt-cpp.md
@@ -2,7 +2,7 @@
 content_title: cdt-cpp tool
 ---
 
-To manually compile the source code, use `cdt-cpp` and `cdt-ld` as if it were __clang__ and __lld__. All the includes and options specific to EOSIO and CDT are baked in.
+To manually compile the source code, use `cdt-cpp` and `cdt-ld` as if it were __clang__ and __lld__. All the includes and options specific to Antelope and CDT are baked in.
 
 ```
 USAGE: cdt-cpp [options] <input file> ...

--- a/docs/03_command-reference/cdt-ld.md
+++ b/docs/03_command-reference/cdt-ld.md
@@ -2,7 +2,7 @@
 content_title: cdt-ld tool
 ---
 
-The cdt-ld tool is a the custom web assembly linker for EOSIO platform smart contracts.
+The cdt-ld tool is a the custom web assembly linker for Antelope framework smart contracts.
 
 
 ```

--- a/docs/05_features/10_return_values_from_actions.md
+++ b/docs/05_features/10_return_values_from_actions.md
@@ -8,13 +8,13 @@ An Antelope blockchain with the `ACTION_RETURN_VALUE` protocol feature activated
 
 ## Concept
 
-When you implement an action within a smart contract use the `return` statement and pass any value to the action sender. The returned value can be of any C++ primitive type, any C++ standard library type, or any user defined type. The `EOSIO` framework does all the work necessary to serialize the value returned and send it back to the client. On the client side you deserialize the received value and access it the same way you access any other function’s return value.
+When you implement an action within a smart contract use the `return` statement and pass any value to the action sender. The returned value can be of any C++ primitive type, any C++ standard library type, or any user defined type. The `Antelope` framework does all the work necessary to serialize the value returned and send it back to the client. On the client side you deserialize the received value and access it the same way you access any other function’s return value.
 
 ## Details
 
 The following list provides important details for when you return a value from an action:
 
-* As mentioned above, the `EOSIO` framework does all the heavy lifting for the return value to convey it to the client. The `EOSIO` framework defines and uses a new intrinsic, namely `set_action_return_value`. To learn more about `EOSIO` returned values functionality, refer to its documentation and [implementation](https://github.com/AntelopeIO/cdt/blob/develop/libraries/native/intrinsics.cpp#L295).
+* As mentioned above, the `Antelope` framework does all the heavy lifting for the return value to convey it to the client. The `Antelope` framework defines and uses a new intrinsic, namely `set_action_return_value`. To learn more about `Antelope` returned values functionality, refer to its documentation and [implementation](https://github.com/AntelopeIO/cdt/blob/develop/libraries/native/intrinsics.cpp#L295).
 * The CPU time and memory limit of your contract (maximum size of wasm), not RAM or NET, defines the limits of the returned value..
 * The action receipt includes a hash of the serialized returned value.
 * The action trace includes the serialized returned value.

--- a/docs/06_how-to-guides/20_authorization/how_to_restrict_access_to_an_action_by_user.md
+++ b/docs/06_how-to-guides/20_authorization/how_to_restrict_access_to_an_action_by_user.md
@@ -16,10 +16,10 @@ This guide provides instructions how to perform authorization checks in a smart 
 
 See the following code reference guides for functions which can be used to implement authorization checks in a smart contract:
 
-* function [has_auth(name n)](https://developers.eos.io/manuals/eosio.cdt/latest/namespaceeosio#function-has_auth)
-* function [require_auth(name n)](https://developers.eos.io/manuals/eosio.cdt/latest/namespaceeosio/#function-require_auth-12)
-* function [require_auth2(capi_name name, capi_name permission)](https://developers.eos.io/manuals/eosio.cdt/v1.8/group__action__c#function-require_auth2)
-* function [check(bool pred, ...)](https://developers.eos.io/manuals/eosio.cdt/latest/group__system/#function-check)
+* function [has_auth(name n)](http://docs.eosnetwork.com/cdt/latest/reference/Namespaces/namespaceeosio#function-has_auth)
+* function [require_auth(name n)](http://docs.eosnetwork.com/cdt/latest/reference/Namespaces/namespaceeosio#function-require_auth)
+* function [require_auth2(capi_name name, capi_name permission)](http://docs.eosnetwork.com/cdt/latest/reference/Files/action_8h)
+* function [check(bool pred, ...)](http://docs.eosnetwork.com/cdt/latest/reference/Namespaces/namespaceeosio#function-check)
 
 ## Procedure
 
@@ -45,7 +45,7 @@ void hi( name user ) {
 }
 ```
 
-Another example can be found in the [Tic Tac Toe Tutorial](https://developers.eos.io/welcome/latest/tutorials/tic-tac-toe-game-contract/#action-handler---move).
+Another example can be found in the [Tic Tac Toe Tutorial](https://docs.eosnetwork.com/welcome/latest/tutorials/tic-tac-toe-game-contract#action-handler---move).
 
 ### 2. Use require_auth
 

--- a/docs/06_how-to-guides/40_multi-index/how-to-define-a-primary-index.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-define-a-primary-index.md
@@ -16,7 +16,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 
 ## Procedure
 
@@ -78,7 +78,7 @@ Add the definition of the primary index for the multi-index table. The primary i
 
 ### 4. Define A Multi-Index Type Alias
 
-For ease of use, define a type alias `test_table_t` based on the `eosio::multi_index` template type, parametarized with a random name `"testtaba"` and the `test_table` data structure. The names must adhere to `EOSIO` account name restrictions.
+For ease of use, define a type alias `test_table_t` based on the `eosio::multi_index` template type, parametarized with a random name `"testtaba"` and the `test_table` data structure. The names must adhere to `Antelope` account name restrictions.
 
   ```diff
     // the data structure which defines each row of the table

--- a/docs/06_how-to-guides/40_multi-index/how-to-define-a-secondary-index.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-define-a-secondary-index.md
@@ -16,7 +16,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 * A multi-index table `testtab` along with its `test_table` data structure, its mandatory primary index, and the type alias definition `test_table_t`. Please see [How To Define A Primary Index](./how-to-define-a-primary-index) to set up these prerequisites.
 
 ## Procedure

--- a/docs/06_how-to-guides/40_multi-index/how-to-define-a-singleton.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-define-a-singleton.md
@@ -16,7 +16,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 
 ## Procedure
 
@@ -45,7 +45,7 @@ Define the data structure for the multi-index table:
 
 ### 3. Define A Singleton Type Alias
 
-For ease of use, define a type alias `singleton_type` based on the `eosio::singleton` template type, parametarized with a random name `"testtable"` and the `testtable` data structure. The names must adhere to `EOSIO` account name restrictions.
+For ease of use, define a type alias `singleton_type` based on the `eosio::singleton` template type, parametarized with a random name `"testtable"` and the `testtable` data structure. The names must adhere to `Antelope` account name restrictions.
 
    ```diff
    struct [[eosio::table]] testtable {

--- a/docs/06_how-to-guides/40_multi-index/how-to-delete-data-from-a-multi-index-table.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-delete-data-from-a-multi-index-table.md
@@ -18,7 +18,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 * A multi-index `testab` table instance which stores `user` objects indexed by the primary key which is of type `eosio::name`. Consult the section [How to instantiate a multi-index table](./how-to-instantiate-a-multi-index-table.md) to learn how to set it up.
 
 ## Procedure

--- a/docs/06_how-to-guides/40_multi-index/how-to-insert-data-into-a-multi-index-table.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-insert-data-into-a-multi-index-table.md
@@ -18,7 +18,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 * A multi-index `testab` table instance which stores `user` objects indexed by the primary key which is of type `eosio::name`. Consult the section [How to instantiate a multi-index table](./how-to-instantiate-a-multi-index-table.md) to learn how to set it up.
 
 ## Procedure

--- a/docs/06_how-to-guides/40_multi-index/how-to-instantiate-a-multi-index-table.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-instantiate-a-multi-index-table.md
@@ -16,7 +16,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 
 ## Procedure
 
@@ -73,7 +73,7 @@ Add the definition of the primary index for the multi-index table. The primary i
 
 ### 4. Define A Multi-Index Type Alias
 
-For ease of use, define a type alias `test_table_t` based on the `eosio::multi_index` template type, parametarized with a random name `"testtaba"` and the `test_table` data structure. The names must adhere to `EOSIO` account name restrictions.
+For ease of use, define a type alias `test_table_t` based on the `eosio::multi_index` template type, parametarized with a random name `"testtaba"` and the `test_table` data structure. The names must adhere to `Antelope` account name restrictions.
 
 ```diff
   // the data structure which defines each row of the table

--- a/docs/06_how-to-guides/40_multi-index/how-to-iterate-and-retrieve-a-multi_index-table-based-on-secondary-index.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-iterate-and-retrieve-a-multi_index-table-based-on-secondary-index.md
@@ -17,7 +17,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 * A multi-index `testab` table instance which stores `user` objects indexed by the primary key which is of type `eosio::name` and a secondary index for data member `secondary` of type `eosio::name` accessible through `by_secondary()` method. Consult the section [How to define a secondary index](./how-to-define-a-secondary-index) to learn how to set it up.
 
 ## Procedure

--- a/docs/06_how-to-guides/40_multi-index/how-to-iterate-and-retrieve-a-multi_index-table.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-iterate-and-retrieve-a-multi_index-table.md
@@ -17,7 +17,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 * A multi-index `testab` table instance which stores `user` objects indexed by the primary key which is of type `eosio::name`. Consult the section [How to instantiate a multi-index table](./how-to-instantiate-a-multi-index-table) to learn how to set it up.
 
 ## Procedure

--- a/docs/06_how-to-guides/40_multi-index/how-to-modify-data-in-a-multi-index-table.md
+++ b/docs/06_how-to-guides/40_multi-index/how-to-modify-data-in-a-multi-index-table.md
@@ -17,7 +17,7 @@ See the following code reference:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index),
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/),
 * A multi-index `testab` table instance which stores `user` objects indexed by the primary key which is of type `eosio::name`. Consult the section [How to instantiate a multi-index table](./how-to-instantiate-a-multi-index-table) to learn how to set it up.
 
 ## Procedure

--- a/docs/06_how-to-guides/50_how-to-create-and-use-action-wrappers.md
+++ b/docs/06_how-to-guides/50_how-to-create-and-use-action-wrappers.md
@@ -17,7 +17,7 @@ See the following code reference guide for action wrapper:
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index).
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/).
 * A smart contract named `multi_index_example`, defined in file `multi_index_example.hpp`.
 * An action `mod` which modifies the integer value `n` stored for row with key `user`.
 

--- a/docs/06_how-to-guides/60_how-to-return-values-from-actions.md
+++ b/docs/06_how-to-guides/60_how-to-return-values-from-actions.md
@@ -12,7 +12,7 @@ In order to accomplish this, use the `return` statement and pass the desired ret
 
 Make sure you have the following prerequisites in place:
 
-* An EOSIO development environment, for details consult the [Get Started Guide](https://developers.eos.io/welcome/latest/getting-started-guide/index).
+* An Antelope development environment, for details consult the [Get Started Guide](https://docs.eosnetwork.com/welcome/latest/getting-started/).
 * A smart contract, let’s call it `smrtcontract`, which builds without error.
 * An action, let’s call it `checkwithrv`, from which you want to return a value of a user defined type `action_response`.
 
@@ -68,7 +68,7 @@ For a complete example of a smart contract that implements an action which retur
 
 ## Next Steps
 
-* Compile the smart contract and deploy it to the EOSIO testnet or any EOSIO based blockchain.
+* Compile the smart contract and deploy it to the Antelope testnet or any Antelope based blockchain.
 * Use the `cleos` command to send the `checkwithrv` action to the smart contract and observe the returned value in the `cleos` output.
 * Use other means (e.g. programmatically) to send the  `checkwithrv` action to the smart contract and observe the returned value in the action trace.
 

--- a/docs/07_best-practices/02_naming-conventions.md
+++ b/docs/07_best-practices/02_naming-conventions.md
@@ -2,11 +2,11 @@
 content_title: Naming conventions
 ---
 
-When implementing EOSIO smart contracts and when storing data in an EOSIO blockchain, it is important to follow the established EOSIO conventions for naming accounts, actions, tables, etc.
+When implementing Antelope smart contracts and when storing data in an Antelope blockchain, it is important to follow the established Antelope conventions for naming accounts, actions, tables, etc.
 
-## EOSIO names
+## Antelope names
 
-*  Applies to all EOSIO encoded names (accounts, actions, tables, etc.)
+*  Applies to all Antelope encoded names (accounts, actions, tables, etc.)
 *  Encoded as a 64-bit unsigned integer (`uint64_t`) on the blockchain.
 *  First 12 characters, if any, encoded in `base32` using characters: `.`, `1-5`, `a-z`
 *  13th character, if applicable, encoded in `base16` using characters: `.`, `1-5`, `a-j`
@@ -34,15 +34,15 @@ When implementing EOSIO smart contracts and when storing data in an EOSIO blockc
 
 The figure below showcases a 12 character string formatted into a 64-bit unsigned integer. Note: the 13th char, if any, contains 2<sup>4</sup> = 16 cases per 1 digit (char): 1 (`.`) + 5 (`1-5`) + 10 (`a-j`).
 
-![](naming-conventions-format.png "EOSIO name format")
+![](naming-conventions-format.png "Antelope name format")
 
 ## Encoding and decoding
 
-EOSIO name objects can be created, encoded, and decoded via the `eosio::name` class.
+Antelope name objects can be created, encoded, and decoded via the `eosio::name` class.
 
-1. To encode an `std::string` into an EOSIO name object, use the appropriate `eosio::name()` constructor.
-2. To encode a `char *` string literal into an EOSIO name object, you can also use the `""_n` operator.
-3. To decode an EOSIO name object into an `std::string`, use the `eosio::to_string()` function.
+1. To encode an `std::string` into an Antelope name object, use the appropriate `eosio::name()` constructor.
+2. To encode a `char *` string literal into an Antelope name object, you can also use the `""_n` operator.
+3. To decode an Antelope name object into an `std::string`, use the `eosio::to_string()` function.
 
 ### Examples
 

--- a/docs/07_best-practices/03_resource-planning.md
+++ b/docs/07_best-practices/03_resource-planning.md
@@ -8,11 +8,11 @@ How much RAM do I need? This is not an easy question to answer, and there's real
 
 You need to test and simulate various business scenarios that apply to your blockchain application and measure their resource usage.  Hence, the existence of the public test networks. These allow you to measure how much RAM, CPU, and NET each action consumes, and to measure worst and best case business scenarios. You can then extrapolate and build a fairly good view of your blockchain application's resource needs.
 
-Once you have a fair idea of how your contract, blockchain application, and user base are consuming blockchain resources on a public test-net you can estimate what you'll need to start with on any EOSIO-based networks, public or private.  From that point onward, as with any other application, it is advisable to have monitors that tell you statistics and metrics about your application performance.
+Once you have a fair idea of how your contract, blockchain application, and user base are consuming blockchain resources on a public test-net you can estimate what you'll need to start with on any Antelope-based networks, public or private.  From that point onward, as with any other application, it is advisable to have monitors that tell you statistics and metrics about your application performance.
 
-Of course some aspects might differ from network to network, because each network might have altered its system contracts.  The EOSIO code base is open sourced and it can be tailored to each network's requirements. You need to be aware of these differences and take them into account if this is the case with a network you're testing on.
+Of course some aspects might differ from network to network, because each network might have altered its system contracts.  The Antelope code base is open sourced and it can be tailored to each network's requirements. You need to be aware of these differences and take them into account if this is the case with a network you're testing on.
 
-The EOSIO community is also providing tools that can help you in this endeavor. One example is https://www.eosrp.io
+The Antelope community is also providing tools that can help you in this endeavor. One example is https://www.eosrp.io
 Because the RAM price varies and because the CPU and NET bandwidth allocations vary too, as it is explained in the previous section, this tool can help you estimate how much of each resource you can allocate based on a specific amount of tokens and vice-versa.
 
 Another aspect of resource planning involves making sure your contract is efficient, that is, not consuming resources unnecessarily. Therefore, it is beneficial for you to find answers to the following questions when writing your own smart contracts and blockchain applications:

--- a/docs/07_best-practices/04_data-design-and-migration.md
+++ b/docs/07_best-practices/04_data-design-and-migration.md
@@ -2,7 +2,7 @@
 content_title: Data design and migration
 ---
 
-EOSIO based blockchains allow developers to easily update their smart contract code. However, a few things need to be considered when it comes to data updates and/or migration. The multi-index table API is one of the mechanisms (Key-Value API being the other) for storing and updating blockchain state. The multi-index table API creates and uses data structures in RAM. Once created and deployed on the blockchain there are limitations if you want to update these structures. Below you will find a few approaches to your smart contract data design, updates to this design, and for data migration.
+Antelope based blockchains allow developers to easily update their smart contract code. However, a few things need to be considered when it comes to data updates and/or migration. The multi-index table API is one of the mechanisms (Key-Value API being the other) for storing and updating blockchain state. The multi-index table API creates and uses data structures in RAM. Once created and deployed on the blockchain there are limitations if you want to update these structures. Below you will find a few approaches to your smart contract data design, updates to this design, and for data migration.
 
 # How to modify a data structure defined using multi-index table API
 

--- a/docs/07_best-practices/05_securing_your_contract.md
+++ b/docs/07_best-practices/05_securing_your_contract.md
@@ -8,7 +8,7 @@ The following are basic recommendations which can be the foundation for securing
 
 ### 1. Authorization Checks
 
-The following methods are available in the `EOSIO` library and they can be used to implemented authorization checks in your smart contracts:
+The following methods are available in the `Antelope` library and they can be used to implemented authorization checks in your smart contracts:
 
 - [`has_auth`](../group__action/#function-has_auth)
 - [`require_auth`](../group__action/#function-require_auth)

--- a/docs/07_best-practices/08_abi/00_understanding-abi-files.md
+++ b/docs/07_best-practices/08_abi/00_understanding-abi-files.md
@@ -35,7 +35,7 @@ Start with an empty ABI, for exemplification we will work based on the `eosio.to
 An ABI enables any client or interface to interpret and even generate a GUI for your contract. For this to work consistently, describe the custom types that are used as a parameter in any public action or struct that needs to be described in the ABI.
 
 [[info | Built-in Types]]
-| EOSIO implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with EOSIO's built-ins, they are defined [here](https://github.com/AntelopeIO/leap/blob/6817911900a088c60f91563995cf482d6b380b2d/libraries/chain/abi_serializer.cpp#L88-L129)
+| Antelope implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with Antelope's built-ins, they are defined [here](https://github.com/AntelopeIO/leap/blob/6817911900a088c60f91563995cf482d6b380b2d/libraries/chain/abi_serializer.cpp#L88-L129)
 
 
 ```json
@@ -86,9 +86,9 @@ In the `eosio.token` contract, there's a number of structs that require definiti
 
 ## Implicit Structs
 
-The following structs are implicit in that a struct was never explicitly defined in the contract. Looking at the [create](https://developers.eos.io/manuals/eosio.contracts/latest/action-reference/eosio.token/index/#create) action, you'll find two parameters, `issuer` of type `name ` and `maximum_supply` of type `asset`. For brevity this tutorial won't break down every struct, but applying the same logic, you will end up with the following:
+The following structs are implicit in that a struct was never explicitly defined in the contract. Looking at the [create](http://docs.eosnetwork.com/system-contracts/latest/reference/Classes/classeosio_1_1token#function-create) action, you'll find two parameters, `issuer` of type `name ` and `maximum_supply` of type `asset`. For brevity this tutorial won't break down every struct, but applying the same logic, you will end up with the following:
 
-### [create](https://developers.eos.io/manuals/eosio.contracts/latest/action-reference/eosio.token/index/#create)
+### [create](http://docs.eosnetwork.com/system-contracts/latest/reference/Classes/classeosio_1_1token#function-create)
 
 ```json
 {
@@ -106,7 +106,7 @@ The following structs are implicit in that a struct was never explicitly defined
   ]
 }
 ```
-### [issue](https://developers.eos.io/manuals/eosio.contracts/latest/action-reference/eosio.token/index/#issue)
+### [issue](http://docs.eosnetwork.com/system-contracts/latest/reference/Classes/classeosio_1_1token#function-issue)
 
 ```json
 {
@@ -128,7 +128,7 @@ The following structs are implicit in that a struct was never explicitly defined
   ]
 }
 ```
-### [retire](https://developers.eos.io/manuals/eosio.contracts/latest/action-reference/eosio.token/index/#retire)
+### [retire](http://docs.eosnetwork.com/system-contracts/latest/reference/Classes/classeosio_1_1token#function-retire)
 
 ```json
 {
@@ -147,7 +147,7 @@ The following structs are implicit in that a struct was never explicitly defined
 }
 ```
 
-### [transfer](https://developers.eos.io/manuals/eosio.contracts/latest/action-reference/eosio.token/index/#transfer)
+### [transfer](http://docs.eosnetwork.com/system-contracts/latest/reference/Classes/classeosio_1_1token#function-transfer)
 
 ```json
 {
@@ -174,7 +174,7 @@ The following structs are implicit in that a struct was never explicitly defined
 }
 ```
 
-### [close](https://developers.eos.io/manuals/eosio.contracts/latest/action-reference/eosio.token/index/#close)
+### [close](http://docs.eosnetwork.com/system-contracts/latest/reference/Classes/classeosio_1_1token#function-close)
 
 ```json
 {
@@ -194,9 +194,10 @@ The following structs are implicit in that a struct was never explicitly defined
 ```
 
 ## Explicit Structs
+
 These structs are explicitly defined, as they are a requirement to instantiate a multi-index table. Describing them is no different than defining the implicit structs as demonstrated above.
 
-### [account](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L120)
+### [account](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L120)
 
 ```json
 {
@@ -222,13 +223,13 @@ An action's JSON object definition looks like the following:
   "ricardian_contract": "" 	//An optional ricardian clause to associate to this action describing its intended functionality.
 }
 ```
-Describe the actions of the `eosio.token` contract by aggregating all the public functions described in the `eosio.token` contract's [header file](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp).
+Describe the actions of the `eosio.token` contract by aggregating all the public functions described in the `eosio.token` contract's [header file](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp).
 
 Then describe each action's *type* according to its previously described struct. In most situations, the function name and the struct name will be equal, but are not required to be equal.
 
 Below is a list of actions that link to their source code with example JSON provided for how each action would be described.
 
-##  [create](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L35-L37)
+##  [create](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L35-L37)
 
 ```json
 {
@@ -238,7 +239,7 @@ Below is a list of actions that link to their source code with example JSON prov
 }
 ```
 
-## [issue](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L45-L46)
+## [issue](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L45-L46)
 
 ```json
 {
@@ -248,7 +249,7 @@ Below is a list of actions that link to their source code with example JSON prov
 }
 ```
 
-## [retire](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L55-L56)
+## [retire](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L55-L56)
 
 ```json
 {
@@ -258,7 +259,7 @@ Below is a list of actions that link to their source code with example JSON prov
 }
 ```
 
-## [transfer](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L67-L71)
+## [transfer](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L67-L71)
 
 ```json
 {
@@ -268,7 +269,7 @@ Below is a list of actions that link to their source code with example JSON prov
 }
 ```
 
-## [close](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L96-L97)
+## [close](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L96-L97)
 
 ```json
 {
@@ -292,9 +293,9 @@ Describe the tables. Here's a table's JSON object definition:
 }
 ```
 
-The eosio.token contract instantiates two tables, [accounts](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L134) and [stat](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L135).
+The eosio.token contract instantiates two tables, [accounts](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L134) and [stat](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L135).
 
-The `accounts` table is an i64 index, based on the [`account` struct](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L120-L124), has a [`uint64` as it's primary key](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L123)
+The `accounts` table is an i64 index, based on the [`account` struct](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L120-L124), has a [`uint64` as it's primary key](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L123)
 
 Here's how the accounts table would be described in the ABI
 
@@ -308,7 +309,7 @@ Here's how the accounts table would be described in the ABI
 }
 ```
 
-The `stat` table is an i64 index, based on the [`currency_stats` struct](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L126-L132), has a [`uint64` as it's primary key](https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L131)
+The `stat` table is an i64 index, based on the [`currency_stats` struct](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L126-L132), has a [`uint64` as it's primary key](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L131)
 
 Here's how the stat table would be described in the ABI
 
@@ -506,7 +507,21 @@ When describing a vector in your ABI file, simply append the type with `[]`, so 
 
 It's a rarely used property worth mentioning. You can use **base** ABI struct property to reference another struct for inheritance, as long as that struct is also described in the same ABI file. Base will do nothing or potentially throw an error if your smart contract logic does not support inheritance.
 
-You can see an example of base in use in the system contract [source code](https://github.com/EOSIO/eosio.contracts/blob/4e4a3ca86d5d3482dfac85182e69f33c49e62fa9/eosio.system/include/eosio.system/eosio.system.hpp#L46) and [ABI](https://github.com/EOSIO/eosio.contracts/blob/4e4a3ca86d5d3482dfac85182e69f33c49e62fa9/eosio.system/abi/eosio.system.abi#L262)
+You can see an example of base in use in the system contract [source code](https://github.com/AntelopeIO/reference-contracts/blob/9d9401e1bd937406b4e2c4f2fd234f22a2d6e3bc/contracts/eosio.system/include/eosio.system/eosio.system.hpp#L141).
+
+The corresponsing ABI definition would look like this:
+
+```json
+{
+      "name": "eosio_global_state",
+      "base": "blockchain_parameters",
+      "fields": [
+         {"name":"max_ram_size",                  "type":"uint64"},
+         {"name":"total_ram_bytes_reserved",      "type":"uint64"},
+         {"name":"total_ram_stake",               "type":"int64"},
+      ]
+}
+```
 
 ## Extra ABI Properties Not Covered Here
 

--- a/docs/07_best-practices/08_abi/01_abi-code-generator-attributes-explained.md
+++ b/docs/07_best-practices/08_abi/01_abi-code-generator-attributes-explained.md
@@ -32,7 +32,7 @@ struct __attribute__((eosio_action)) testa {
 };
 ```
 
-If your action name is not a valid [EOSIO name](../02_naming-conventions.md) you can explicitly specify the name in the attribute ```c++ [[eosio::action("<valid action name>")]]```
+If your action name is not a valid [Antelope name](../02_naming-conventions.md) you can explicitly specify the name in the attribute ```c++ [[eosio::action("<valid action name>")]]```
 
 ## [[eosio::table]]
 Example (two ways to declare a table for ABI generation):
@@ -58,7 +58,7 @@ class [[eosio::contract("ANY_NAME_YOU_LIKE")]] test_contract : public eosio::con
 };
 ```
 
-The code above will mark this `class` as being an `EOSIO` contract, this allows for namespacing of contracts, i.e. you can include headers like `eosio::token` and not have `eosio::token`'s actions/tables wind up in you ABI or generated dispatcher.
+The code above will mark this `class` as being an `Antelope` contract, this allows for namespacing of contracts, i.e. you can include headers like `eosio::token` and not have `eosio::token`'s actions/tables wind up in you ABI or generated dispatcher.
 
 ## [[eosio::on_notify("VALID_EOSIO_ACCOUNT_NAME::VALID_EOSIO_ACTION_NAME")]]
 ```cpp

--- a/docs/07_best-practices/11_debugging_a_smart_contract.md
+++ b/docs/07_best-practices/11_debugging_a_smart_contract.md
@@ -8,12 +8,14 @@ When you are creating your smart contract for the first time, it is recommended 
 
 The concept is the same, so for the following guide, debugging on the private testnet will be covered.
 
-If you haven't set up your own local nodeos, follow the [setup guide](https://developers.eos.io/eosio-home/docs/getting-the-software). By default, your local nodeos will just run in a private testnet unless you modify the config.ini file to connect with public testnet (or official testnet) nodes. 
+If you haven't set up your own local nodeos, follow the [DUNE setup guide](https://github.com/AntelopeIO/DUNE#readme). By default, your local nodeos will just run in a private testnet unless you modify the config.ini file to connect with public testnet (or official testnet) nodes.
 
 # Method
+
 The main method used to debug smart contract is **Caveman Debugging**. Printing is utilized to inspect the value of a variable and check the flow of the contract. Printing in smart contracts can be done through the Print API. The C++ API is a wrapper for C API and is the recommended API.
 
 # Print
+
 Print C API supports the following data type that you can print:
 - prints - a null terminated char array (string)
 - prints_l - any char array (string) with given size

--- a/docs/08_troubleshooting/index.md
+++ b/docs/08_troubleshooting/index.md
@@ -95,7 +95,7 @@ __Possible solution__: make sure you have at least 2 cores on the host that exec
 
 ## You can not find the `now()` time function, or the result of the `current_time_point` functions are not what you expected them to be
 
-__Possible solution__: The `now()` function has been replaced by `current_time_point().sec_since_epoch()`, it returns the time in microseconds from 1970 of the `current block` as a time_point. There's also available `current_block_time()` which returns the time in microseconds from 1970 of the `current block` as a `block_timestamp`. Be aware that for time base functions, the assumption is when you call something like `now()` or `current_time()` you will get the exact now/current time, however that is not the case with EOSIO, you get __the block time__, and only ever get __the block time__ from the available `sec_since_epoch()` or `current_block_time()` no matter how many times you call it.
+__Possible solution__: The `now()` function has been replaced by `current_time_point().sec_since_epoch()`, it returns the time in microseconds from 1970 of the `current block` as a time_point. There's also available `current_block_time()` which returns the time in microseconds from 1970 of the `current block` as a `block_timestamp`. Be aware that for time base functions, the assumption is when you call something like `now()` or `current_time()` you will get the exact now/current time, however that is not the case with Antelope, you get __the block time__, and only ever get __the block time__ from the available `sec_since_epoch()` or `current_block_time()` no matter how many times you call it.
 
 ## You successfully re-deployed the contract code, but when you broadcast one of the contracts methods to the blockchain you get below error message
 
@@ -133,7 +133,7 @@ The below code will print all lines of the iteration separated by `'|'` char.
 
 ## Print statements from smart contract code are not shown in the `expected order`
 
-__Possible solution__: The key point here is the `expected order` and what you think it should be. Although the EOSIO is single threaded, when looking at your smart contract action code implementation, which let's say it has a series of `print` (either `print_f` or `printf`) statements, they might not necessarily be outputted in the order the `apparent` code workflow is. One example is when inline transactions are sent from your smart contract action code, and you expect to see the `print` statements from within the inline action code outputted before the `print` statements made after the inline action `send` statement. For better exemplification let's look at the code below:
+__Possible solution__: The key point here is the `expected order` and what you think it should be. Although the Antelope is single threaded, when looking at your smart contract action code implementation, which let's say it has a series of `print` (either `print_f` or `printf`) statements, they might not necessarily be outputted in the order the `apparent` code workflow is. One example is when inline transactions are sent from your smart contract action code, and you expect to see the `print` statements from within the inline action code outputted before the `print` statements made after the inline action `send` statement. For better exemplification let's look at the code below:
 
 ```cpp
 [[eosio::action]] void multi_index_example::mod( name user, uint64_t n ) {
@@ -164,4 +164,4 @@ assertion failure with message: system contract must first be initialized
 ```
 
 The failure is stating that `eosio.system` `init` action was not called yet. The `init` action is implemented by the `void init(uint64_t, symbol)` function. The first parameter is the version, this should always be `0` for now, until a new version of `init` will be created that handles more information.
-The second parameter is the system's symbol (i.e. for main net this is `EOS`). If you followed the [BIOS Boot Sequence](https://developers.eos.io/welcome/latest/tutorials/bios-boot-sequence) tutorial and created a system with the default symbol `SYS` then `SYS` shall be used as the system's symbol in the `init` action. It is whatever symbol you as the chain creator want to use in your `EOSIO` based blockchain.
+The second parameter is the system's symbol (i.e. for main net this is `EOS`). If you followed the [BIOS Boot Sequence](https://docs.eosnetwork.com/welcome/latest/tutorials/bios-boot-sequence) tutorial and created a system with the default symbol `SYS` then `SYS` shall be used as the system's symbol in the `init` action. It is whatever symbol you as the chain creator want to use in your `Antelope` based blockchain.

--- a/docs/09_tutorials/02_abi-variants.md
+++ b/docs/09_tutorials/02_abi-variants.md
@@ -5,7 +5,7 @@ link_text: ABI variants
 
 ABI variants give the flexibility of using more than one type for a defined variable or data member.
 
-In EOSIO, the variants use the standard template library `variant` which was introduced in C++ 17. An instance of `std::variant` at any given time either holds a value of one of its alternative types, or in the case of error - no value. Because of this trait, variants can be used to build the multi-index table structure with flexibility. Used in conjunction with ABI extensions, it allows for modification of the structure of an existing multi-index table, a.k.a. table.
+In Antelope, the variants use the standard template library `variant` which was introduced in C++ 17. An instance of `std::variant` at any given time either holds a value of one of its alternative types, or in the case of error - no value. Because of this trait, variants can be used to build the multi-index table structure with flexibility. Used in conjunction with ABI extensions, it allows for modification of the structure of an existing multi-index table, a.k.a. table.
 
 ## Use variant when building the multi-index table the first time
 

--- a/docs/09_tutorials/03_create-an-abi-file.md
+++ b/docs/09_tutorials/03_create-an-abi-file.md
@@ -10,7 +10,7 @@ This tutorial provides instructions to how to hand-write an ABI file. This shoul
 
 The Application Binary Interface (ABI) is a JSON-based description to convert user actions between their JSON and Binary representations. The ABI also describes how to convert the database state to/from JSON. Once you have described your contract via an ABI then developers and users will be able to interact with your contract seamlessly via JSON.
 
-This tutorial will use the [eosio.token](https://github.com/EOSIO/eosio.contracts/tree/master/eosio.token) contract as an example. *eosio.token contract does not cover every possible permutation of an ABI definition.  
+This tutorial will use the [eosio.token](https://github.com/AntelopeIO/reference-contracts/tree/main/contracts/eosio.token) contract as an example. *eosio.token contract does not cover every possible permutation of an ABI definition.  
 
 To make things easy, we will start with an empty ABI.
 
@@ -35,7 +35,7 @@ An ABI enables any client or interface to interpret and even generate an GUI for
 [[info]]
 |Built-in Types
 
-EOSIO implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with EOSIO's built-ins, they are defined [here](https://github.com/AntelopeIO/leap/blob/6817911900a088c60f91563995cf482d6b380b2d/libraries/chain/abi_serializer.cpp#L88-L129).
+Antelope implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with Antelope's built-ins, they are defined [here](https://github.com/AntelopeIO/leap/blob/6817911900a088c60f91563995cf482d6b380b2d/libraries/chain/abi_serializer.cpp#L88-L129).
 
 Using **eosio.token** as an example, the only type that requires a description in the ABI file is `account_name`. The ABI uses "new_type_name" to describe explicit types, in this case `account_name`, and `account_name` is an alias of `name` type.
 
@@ -90,9 +90,9 @@ Looking through the `eosio.token` contract, we see a number of structs that requ
 
 ## Implicit Structs
 
-The following structs are implicit in that a struct was never explicitly defined in the contract. Looking at the [create](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L24) action, you'll find two parameters, `issuer` of type `account_name ` and `maximum_supply` of type `asset`. For brevity this tutorial won't break down every struct, but applying the same logic, you will end up with the following:
+The following structs are implicit in that a struct was never explicitly defined in the contract. Looking at the [create](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L24) action, you'll find two parameters, `issuer` of type `account_name ` and `maximum_supply` of type `asset`. For brevity this tutorial won't break down every struct, but applying the same logic, you will end up with the following:
 
-### [create](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L24)
+### [create](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L24)
 
 ```json
 {
@@ -111,7 +111,7 @@ The following structs are implicit in that a struct was never explicitly defined
 }
 ```
 
-### [issue](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L27)
+### [issue](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L27)
 
 ```json
 {
@@ -134,7 +134,7 @@ The following structs are implicit in that a struct was never explicitly defined
 }
 ```
 
-### [retire](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L29)
+### [retire](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L29)
 
 ```json
 {
@@ -153,7 +153,7 @@ The following structs are implicit in that a struct was never explicitly defined
 }
 ```
 
-### [transfer](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L31-L34)
+### [transfer](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L31-L34)
 
 ```json
 {
@@ -180,7 +180,7 @@ The following structs are implicit in that a struct was never explicitly defined
 }
 ```
 
-### [close](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L36)
+### [close](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L36)
 
 ```json
 {
@@ -202,7 +202,7 @@ The following structs are implicit in that a struct was never explicitly defined
 ## Explicit Structs
 These structs are explicitly defined, as they are a requirement to instantiate a multi-index table. Describing them is no different than defining the implicit structs as demonstrated above.
 
-### [account](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L43-L47)
+### [account](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L43-L47)
 
 ```json
 {
@@ -217,7 +217,7 @@ These structs are explicitly defined, as they are a requirement to instantiate a
 }
 ```
 
-### [currency_stats](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L49-L55)
+### [currency_stats](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L49-L55)
 
 ```json
 {
@@ -252,11 +252,11 @@ An action's JSON object definition looks like the following:
 }
 ```
 
-Next, we'll describe the actions of the `eosio.token` contract by aggregating all the public functions describe in the `eosio.token` contract's [header file](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L24-L36). We'll then describe each action's *type* to their previously described struct. In most situations, the function name and the struct name will be equal, but are not required to be equal.
+Next, we'll describe the actions of the `eosio.token` contract by aggregating all the public functions describe in the `eosio.token` contract's [header file](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L24-L36). We'll then describe each action's *type* to their previously described struct. In most situations, the function name and the struct name will be equal, but are not required to be equal.
 
 Below is a list of actions that link to their source code with example JSON provided for how each action would be described.
 
-## [create](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L24-L25)
+## [create](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L24-L25)
 
 ```json
 {
@@ -266,7 +266,7 @@ Below is a list of actions that link to their source code with example JSON prov
 }
 ```
 
-## [issue](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L27)
+## [issue](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L27)
 
 ```json
 {
@@ -276,7 +276,7 @@ Below is a list of actions that link to their source code with example JSON prov
 }
 ```
 
-## [retire](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L31-L34)
+## [retire](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L31-L34)
 
 ```json
 {
@@ -286,7 +286,7 @@ Below is a list of actions that link to their source code with example JSON prov
 }
 ```
 
-## [transfer](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L31-L34)
+## [transfer](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L31-L34)
 
 ```json
 {
@@ -296,7 +296,7 @@ Below is a list of actions that link to their source code with example JSON prov
 }
 ```
 
-## [close](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L36)
+## [close](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L36)
 
 ```json
 {
@@ -322,9 +322,9 @@ Finally, we need to describe our tables. Here's a table's JSON object definition
 }
 ```
 
-The eosio.token contract instantiates two tables, [accounts](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L57) and [stat](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L58).
+The eosio.token contract instantiates two tables, [accounts](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L57) and [stat](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L58).
 
-The accounts table is an i64 index, based on the [`account` struct](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L43-L47), has a [`uint64` as it's primary key](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L46) and it's key been arbitrarily named "currency".
+The accounts table is an i64 index, based on the [`account` struct](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L43-L47), has a [`uint64` as it's primary key](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L46) and it's key been arbitrarily named "currency".
 
 Here's how the accounts table would be described in the ABI
 
@@ -338,7 +338,7 @@ Here's how the accounts table would be described in the ABI
 }
 ```
 
-The stat table is an i64 index, based on the [`currenct_stats` struct](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L49-L55), has a [`uint64` as it's primary key](https://github.com/EOSIO/eosio.contracts/blob/master/eosio.token/include/eosio.token/eosio.token.hpp#L54) and it's key been arbitrarily named "currency"
+The stat table is an i64 index, based on the [`currenct_stats` struct](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L49-L55), has a [`uint64` as it's primary key](https://github.com/AntelopeIO/reference-contracts/blob/main/contracts/eosio.token/include/eosio.token/eosio.token.hpp#L54) and it's key been arbitrarily named "currency"
 
 Here's how the stat table would be described in the ABI
 
@@ -537,7 +537,21 @@ When describing a vector in your ABI file, simply append the type with `[]`, so 
 
 It's a rarely used property worth mentioning. You can use **base** ABI struct property to reference another struct for inheritance, as long as that struct is also described in the same ABI file. Base will do nothing or potentially throw an error if your smart contract logic does not support inheritance.
 
-You can see an example of base in use in the system contract [source code](https://github.com/EOSIO/eosio.contracts/blob/4e4a3ca86d5d3482dfac85182e69f33c49e62fa9/eosio.system/include/eosio.system/eosio.system.hpp#L46) and [ABI](https://github.com/EOSIO/eosio.contracts/blob/4e4a3ca86d5d3482dfac85182e69f33c49e62fa9/eosio.system/abi/eosio.system.abi#L262)
+You can see an example of base in use in the system contract [source code](https://github.com/AntelopeIO/reference-contracts/blob/9d9401e1bd937406b4e2c4f2fd234f22a2d6e3bc/contracts/eosio.system/include/eosio.system/eosio.system.hpp#L141).
+
+The corresponsing ABI definition would look like this:
+
+```json
+{
+      "name": "eosio_global_state",
+      "base": "blockchain_parameters",
+      "fields": [
+         {"name":"max_ram_size",                  "type":"uint64"},
+         {"name":"total_ram_bytes_reserved",      "type":"uint64"},
+         {"name":"total_ram_stake",               "type":"int64"},
+      ]
+}
+```
 
 ## ABI Properties Not Covered Here
 


### PR DESCRIPTION
## Clean up: EOSIO to Antelope

Replace deprecated terms, e.g. block.one, b1, EOSIO, platform (with framework)
Fix broken links

Resolves https://github.com/AntelopeIO/cdt/issues/37
Resolves https://github.com/eosnetworkfoundation/devrel/issues/32
