### PR TITLE
[3.0] fix inconsistency in ABI generated for map

### DIFF
--- a/tests/toolchain/abigen-pass/nested_container.abi
+++ b/tests/toolchain/abigen-pass/nested_container.abi
@@ -31,11 +31,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "string"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "B_map_string_string_E"
                 }
             ]
@@ -45,11 +45,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "string"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "string"
                 }
             ]

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -178,8 +178,8 @@ namespace eosio { namespace cdt {
             return name.substr(0,i+1);
          };
          map_info.name = remove_ending_brackets(name);
-         map_info.fields.push_back( {"key", get_template_argument_as_string(type)} );
-         map_info.fields.push_back( {"value", get_template_argument_as_string(type, 1)} );
+         map_info.fields.push_back( {"first", get_template_argument_as_string(type)} );
+         map_info.fields.push_back( {"second", get_template_argument_as_string(type, 1)} );
          add_type(std::get<clang::QualType>(get_template_argument(type)));
          add_type(std::get<clang::QualType>(get_template_argument(type, 1)));
          _abi.structs.insert(map_info);
@@ -326,8 +326,8 @@ namespace eosio { namespace cdt {
 
             abi_struct kv;
             kv.name = "pair_" + inside_type_name[0] + "_" + inside_type_name[1];
-            kv.fields.push_back( {"key", inside_type_name[0]} );
-            kv.fields.push_back( {"value", inside_type_name[1]} );
+            kv.fields.push_back( {"first", inside_type_name[0]} );
+            kv.fields.push_back( {"second", inside_type_name[1]} );
             _abi.structs.insert(kv);
 
             gottype = true;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Resolve https://github.com/AntelopeIO/cdt/issues/34.

Please see https://github.com/AntelopeIO/cdt/issues/34 for detailed problem description and solution discussion.

Previously, `map` ABI was a pair of `key` and `value`. If a `pair`'s component types were the same as a `map`, depending on the order of map and pair definition, different ABIs for pair were generated.

For example, before the fix, `pair_int32_int64` were different depending on `my_map` was defined before or after `my_pair`:
```
std::map<int32_t, int64_t> my_map; 
std::pair<int32_t, int64_t> my_pair;
```
generates
```
        {
            "name": "pair_int32_int64",
            "base": "",
            "fields": [
                {
                    "name": "key",
                    "type": "int32"
                },
                {
                    "name": "value",
                    "type": "int64"
                }
            ]
        },
...
        [
                {
                    "name": "my_map",
                    "type": "pair_int32_int64[]"
                },
                {
                    "name": "my_pair",
                    "type": "pair_int32_int64"
                }
        ]
```

```
std::pair<int32_t, int64_t> my_pair;
std::map<int32_t, int64_t> my_map;
```
generates
```
        {
            "name": "pair_int32_int64",
            "base": "",
            "fields": [
                {
                    "name": "first",
                    "type": "int32"
                },
                {
                    "name": "first",
                    "type": "int64"
                }
            ]
        },
...
       [
                {
                    "name": "my_pair",
                    "type": "pair_int32_int64"
                },
                {
                    "name": "my_map",
                    "type": "pair_int32_int64[]"
                }
       ]
```


After the fix, both produce the same ABI for `pair_int32_int64`

   ```
       {
            "name": "pair_int32_int64",
            "base": "",
            "fields": [
                {
                    "name": "first",
                    "type": "int32"
                },
                {
                    "name": "second",
                    "type": "int64"
                }
            ]
        },
...
        [
              {
                    "name": "my_map",
                     "type": "pair_int32_int64[]"
              },
              {
                    "name": "my_pair",
                    "type": "pair_int32_int64"
              }
       ]

```

In addition, Reference Contracts https://github.com/AntelopeIO/reference-contracts were tested against the new CDT and CDT 3.0.0, ABIs generated by both CDTs were the same.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
