### PR TITLE
Replaced char array in output_stream to std::string to avoid buffer overflow

### DIFF
--- a/libraries/native/native/eosio/crt.hpp
+++ b/libraries/native/native/eosio/crt.hpp
@@ -1,23 +1,25 @@
 #pragma once
 #include <setjmp.h>
 
+#include <string>
+
 namespace eosio { namespace cdt {
    enum output_stream_kind {
       std_out,
       std_err,
       none
    };
-   struct output_stream {
-      static constexpr size_t max_size = 1024 * 2;
-      char output[max_size] = {};
-      size_t index = 0;
-      std::string to_string()const { return std::string((const char*)output, index); }
-      const char* get()const { return output; }
-      void push(char c) {
-         if(index < max_size - 1)
-            output[index++] = c;
-      }
-      void clear() { index = 0; }
+   class output_stream {
+      static constexpr size_t initial_size = 1024 * 4;
+      std::string output;
+
+      public:
+      output_stream() { output.reserve(initial_size); }
+      std::string to_string() const { return output; }
+      const char* get() const { return output.c_str(); }
+      size_t index() const { return output.size(); }
+      void push(char c) { output.push_back(c); }
+      void clear() { output.clear(); }
    };
 }} //ns eosio::cdt
 

--- a/libraries/native/native/eosio/crt.hpp
+++ b/libraries/native/native/eosio/crt.hpp
@@ -15,7 +15,7 @@ namespace eosio { namespace cdt {
 
       public:
       output_stream() { output.reserve(initial_size); }
-      std::string to_string() const { return output; }
+      const std::string& to_string() const { return output; }
       const char* get() const { return output.c_str(); }
       size_t index() const { return output.size(); }
       void push(char c) { output.push_back(c); }

--- a/libraries/native/native/eosio/crt.hpp
+++ b/libraries/native/native/eosio/crt.hpp
@@ -8,11 +8,15 @@ namespace eosio { namespace cdt {
       none
    };
    struct output_stream {
-      char output[1024*2];
+      static constexpr size_t max_size = 1024 * 2;
+      char output[max_size] = {};
       size_t index = 0;
       std::string to_string()const { return std::string((const char*)output, index); }
       const char* get()const { return output; }
-      void push(char c) { output[index++] = c; }
+      void push(char c) {
+         if(index < max_size - 1)
+            output[index++] = c;
+      }
       void clear() { index = 0; }
    };
 }} //ns eosio::cdt

--- a/libraries/native/native/eosio/tester.hpp
+++ b/libraries/native/native/eosio/tester.hpp
@@ -51,7 +51,7 @@ template <size_t N, typename F, typename... Args>
 inline bool expect_assert(bool check, const std::string& li, const char (&expected)[N], F&& func, Args... args) {
    return expect_assert(check, li,
          [&](const std::string& s) {
-            return std_err.index == N-1 &&
+            return std_err.index() == N-1 &&
             memcmp(expected, s.c_str(), N-1) == 0; }, func, args...);
 }
 
@@ -75,7 +75,7 @@ template <size_t N, typename F, typename... Args>
 inline bool expect_print(bool check, const std::string& li, const char (&expected)[N], F&& func, Args... args) {
    return expect_print(check, li,
          [&](const std::string& s) {
-            return std_out.index == N-1 &&
+            return std_out.index() == N-1 &&
             memcmp(expected, s.c_str(), N-1) == 0; }, func, args...);
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ endmacro()
 
 add_unit_test( asset_tests )
 add_unit_test( binary_extension_tests )
+add_unit_test( crt_tests )
 add_unit_test( crypto_tests )
 add_unit_test( crypto_ext_tests )
 add_unit_test( datastream_tests )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ endmacro()
 
 add_cdt_unit_test(asset_tests)
 add_cdt_unit_test(binary_extension_tests)
+add_cdt_unit_test(crt_tests)
 add_cdt_unit_test(crypto_tests)
 add_cdt_unit_test(crypto_ext_tests)
 add_cdt_unit_test(datastream_tests)

--- a/tests/unit/crt_tests.cpp
+++ b/tests/unit/crt_tests.cpp
@@ -1,0 +1,53 @@
+/**
+ *  @file
+ *  @copyright defined in eosio.cdt/LICENSE.txt
+ */
+#include <cstdint>
+#include <string>
+
+#include <eosio/tester.hpp>
+#include <eosio/crt.hpp>
+
+#include <cstdio>
+
+using eosio::cdt::output_stream;
+
+EOSIO_TEST_BEGIN(output_stream_push)
+   std_err.clear();
+   const char* msg = "abc";
+   _prints(msg, eosio::cdt::output_stream_kind::std_err);
+   CHECK_EQUAL(std_err.to_string(), "abc");
+
+   std_err.clear();
+   const char* msg2 = "";
+   _prints(msg2, eosio::cdt::output_stream_kind::std_err);
+   CHECK_EQUAL(std_err.to_string(), "");
+
+   std_err.clear();
+EOSIO_TEST_END
+
+EOSIO_TEST_BEGIN(output_stream_push_overflow)
+   std_err.clear();
+   const auto max_size = std_err.max_size;
+
+   char msg[max_size+1] = {};
+   for (auto i = 0; i< max_size; ++i)
+   msg[i] = 'x';
+
+   _prints(msg, eosio::cdt::output_stream_kind::std_err);
+   CHECK_EQUAL(std_err.to_string().size(), max_size - 1);
+
+   std_err.clear();
+EOSIO_TEST_END
+
+int main(int argc, char* argv[]) {
+   bool verbose = false;
+   if( argc >= 2 && std::strcmp( argv[1], "-v" ) == 0 ) {
+      verbose = true;
+   }
+   silence_output(!verbose);
+
+   EOSIO_TEST(output_stream_push)
+   EOSIO_TEST(output_stream_push_overflow)
+   return has_failed();
+}

--- a/tests/unit/crt_tests.cpp
+++ b/tests/unit/crt_tests.cpp
@@ -2,13 +2,13 @@
  *  @file
  *  @copyright defined in eosio.cdt/LICENSE.txt
  */
+
 #include <cstdint>
+#include <cstdio>
 #include <string>
 
 #include <eosio/tester.hpp>
 #include <eosio/crt.hpp>
-
-#include <cstdio>
 
 using eosio::cdt::output_stream;
 
@@ -42,6 +42,19 @@ EOSIO_TEST_BEGIN(output_stream_push_overflow)
    std_err.clear();
 EOSIO_TEST_END
 
+EOSIO_TEST_BEGIN(output_stream_get_and_push)
+   std_err.clear();
+   std::string example_msg("abcdef");
+
+   _prints(example_msg.c_str(), eosio::cdt::output_stream_kind::std_err);
+   CHECK_EQUAL(strcmp(std_err.get(), "abcdef") , 0);
+
+   std_err.push('g');
+   CHECK_EQUAL(strcmp(std_err.get(), "abcdefg") , 0);
+
+   std_err.clear();
+EOSIO_TEST_END
+
 int main(int argc, char* argv[]) {
    bool verbose = false;
    if( argc >= 2 && std::strcmp( argv[1], "-v" ) == 0 ) {
@@ -51,5 +64,6 @@ int main(int argc, char* argv[]) {
 
    EOSIO_TEST(output_stream_push)
    EOSIO_TEST(output_stream_push_overflow)
+   EOSIO_TEST(output_stream_get_and_push)
    return has_failed();
 }

--- a/tests/unit/crt_tests.cpp
+++ b/tests/unit/crt_tests.cpp
@@ -17,25 +17,27 @@ EOSIO_TEST_BEGIN(output_stream_push)
    const char* msg = "abc";
    _prints(msg, eosio::cdt::output_stream_kind::std_err);
    CHECK_EQUAL(std_err.to_string(), "abc");
+   CHECK_EQUAL(std_err.index(), 3);
 
    std_err.clear();
    const char* msg2 = "";
    _prints(msg2, eosio::cdt::output_stream_kind::std_err);
    CHECK_EQUAL(std_err.to_string(), "");
+   CHECK_EQUAL(std_err.index(), 0);
 
    std_err.clear();
 EOSIO_TEST_END
 
 EOSIO_TEST_BEGIN(output_stream_push_overflow)
    std_err.clear();
-   const auto max_size = std_err.max_size;
+   const auto initial_capacity = std_err.to_string().capacity();
+   CHECK_EQUAL(std_err.index(), 0);
 
-   char msg[max_size+1] = {};
-   for (auto i = 0; i< max_size; ++i)
-   msg[i] = 'x';
+   std::string large_msg('x', initial_capacity + 1);
 
-   _prints(msg, eosio::cdt::output_stream_kind::std_err);
-   CHECK_EQUAL(std_err.to_string().size(), max_size - 1);
+   _prints(large_msg.c_str(), eosio::cdt::output_stream_kind::std_err);
+   CHECK_EQUAL(std_err.to_string().capacity() > initial_capacity, true);
+   CHECK_EQUAL(std_err.index(), large_msg.size());
 
    std_err.clear();
 EOSIO_TEST_END


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Solving https://github.com/AntelopeIO/cdt/issues/12
Replaced char buffer with std::string. Initial capacity of string is set to 4096.
Using output_stream::push should no longer cause buffer overflow.

Added unit tests for overflow.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
