### PR TITLE
Implemented interface for bls_signatures

### DIFF
--- a/libraries/eosiolib/capi/eosio/crypto_bls_ext.h
+++ b/libraries/eosiolib/capi/eosio/crypto_bls_ext.h
@@ -1,0 +1,26 @@
+/**
+ *  @file
+ *  @copyright defined in cdt/LICENSE
+ */
+#pragma once
+#include "types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((eosio_wasm_import))
+bool bls_verify( const char* sig, uint32_t sig_len, const char* dig, uint32_t dig_len, char* pub, uint32_t pub_len);
+
+__attribute__((eosio_wasm_import))
+int32_t bls_aggregate_pubkeys( const char* pubs, uint32_t pubs_len, const char* agg, uint32_t agg_len);
+
+__attribute__((eosio_wasm_import))
+int32_t bls_aggregate_sigs( const char* sigs, uint32_t sigs_len, const char* agg, uint32_t agg_len);
+
+__attribute__((eosio_wasm_import))
+bool bls_aggregate_verify( const char* sig, uint32_t sig_len, const char* digs, uint32_t digs_len, char* pubs, uint32_t pubs_len);
+
+#ifdef __cplusplus
+}
+#endif
+/// @}

--- a/libraries/eosiolib/capi/eosio/types.h
+++ b/libraries/eosiolib/capi/eosio/types.h
@@ -45,6 +45,14 @@ capi_signature {
    uint8_t data[66];
 };
 
+struct ALIGNED(capi_bls_public_key) {
+   uint8_t data[48];
+};
+
+struct ALIGNED(capi_bls_signature) {
+   uint8_t data[96];
+};
+
 /**
  * 256-bit hash
  */

--- a/libraries/eosiolib/core/eosio/crypto_bls_ext.hpp
+++ b/libraries/eosiolib/core/eosio/crypto_bls_ext.hpp
@@ -1,0 +1,103 @@
+/**
+ *  @file
+ *  @copyright defined in cdt/LICENSE
+ */
+#pragma once
+
+#include "fixed_bytes.hpp"
+#include "varint.hpp"
+#include "serialize.hpp"
+
+#include <array>
+
+namespace eosio {
+
+
+   //using bls_public_key = std::array<char, 48>;
+   //using bls_signature = std::array<char, 96>;
+
+
+   using bls_public_key = std::array<uint8_t, 49>;
+   using bls_signature = std::array<uint8_t, 97>;
+
+   namespace internal_use_do_not_use {
+      extern "C" {
+
+         __attribute__((eosio_wasm_import))
+         bool bls_verify( const char* sig, uint32_t sig_len, const char* dig, uint32_t dig_len, char* pub, uint32_t pub_len);
+
+         __attribute__((eosio_wasm_import))
+         int32_t bls_aggregate_pubkeys( const char* pubs, uint32_t pubs_len, const char* agg, uint32_t agg_len);
+
+         __attribute__((eosio_wasm_import))
+         int32_t bls_aggregate_sigs( const char* sigs, uint32_t sigs_len, const char* agg, uint32_t agg_len);
+
+         __attribute__((eosio_wasm_import))
+         bool bls_aggregate_verify( const char* sig, uint32_t sig_len, const char* digs, uint32_t digs_len, char* pubs, uint32_t pubs_len);
+
+      }
+
+   }
+
+   bool bls_verify(bls_public_key pub, bls_signature sig , std::vector<uint8_t> msg) {
+
+      auto pub_data = eosio::pack(pub);
+      auto sig_data = eosio::pack(sig);
+      auto msg_data = eosio::pack(msg);
+
+      return internal_use_do_not_use::bls_verify( sig_data.data(), sig_data.size(), msg_data.data(), msg_data.size(), pub_data.data(), pub_data.size() );
+
+   }
+
+   bls_public_key bls_aggregate_pubkeys(std::vector<bls_public_key> pubkeys) {
+
+      auto pubs_data = eosio::pack(pubkeys);
+
+      void* agg_data = alloca(sizeof(bls_public_key));
+
+      int32_t agg_return_size = internal_use_do_not_use::bls_aggregate_pubkeys( pubs_data.data(), pubs_data.size(), reinterpret_cast<char*>(agg_data), sizeof(bls_public_key));
+
+      eosio::datastream< char*> r_agg_data_ds( reinterpret_cast< char*>(agg_data), sizeof(bls_public_key) );
+
+      std::array<uint8_t, sizeof(bls_public_key)> v;
+
+      r_agg_data_ds >> v;
+
+      return v;
+
+   }
+
+
+   bls_signature bls_aggregate_sigs(std::vector<bls_signature> sigs) {
+
+      auto sigs_data = eosio::pack(sigs);
+
+      void* agg_data = alloca(sizeof(bls_signature));
+
+      int32_t agg_return_size = internal_use_do_not_use::bls_aggregate_sigs( sigs_data.data(), sigs_data.size(), reinterpret_cast<char*>(agg_data), sizeof(bls_signature));
+
+      eosio::datastream< char*> r_agg_data_ds( reinterpret_cast< char*>(agg_data), sizeof(bls_signature) );
+
+      std::array<uint8_t, sizeof(bls_signature)> v;
+
+      r_agg_data_ds >> v;
+
+      return v;
+
+   }
+
+   bool bls_aggregate_verify( std::vector<bls_public_key> pubkeys, std::vector<std::vector<uint8_t>> messages, bls_signature sig ){
+
+      auto pub_data = eosio::pack(pubkeys);
+      auto sig_data = eosio::pack(sig);
+      auto msg_data = eosio::pack(messages);
+
+      return internal_use_do_not_use::bls_aggregate_verify( sig_data.data(), sig_data.size(), msg_data.data(), msg_data.size(), pub_data.data(), pub_data.size() );
+
+   }
+
+/*   bool bls_verify( const char* sig, uint32_t sig_len, const char* dig, uint32_t dig_len, char* pub, uint32_t pub_len) {
+      return internal_use_do_not_use::bls_verify( sig, sig_len, dig, dig_len, pub, pub_len );
+   }
+*/
+}

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -936,3 +936,19 @@ int32_t mod_exp( const char* base, uint32_t base_len, const char* exp, uint32_t 
 void sha3( const char* data, uint32_t data_len, char* hash, uint32_t hash_len, int32_t keccak ) {
    intrinsics::get().call<intrinsics::sha3>(data, data_len, hash, hash_len, keccak);
 }
+
+bool bls_verify( const char* sig, uint32_t sig_len, const char* dig, uint32_t dig_len, char* pub, uint32_t pub_len) {
+   return intrinsics::get().call<intrinsics::bls_verify>(sig, sig_len, dig, dig_len, pub, pub_len );
+}
+
+int32_t bls_aggregate_pubkeys( const char* pubs, uint32_t pubs_len, const char* agg, uint32_t agg_len) {
+   return intrinsics::get().call<intrinsics::bls_aggregate_pubkeys>(pubs, pubs_len, agg, agg_len );
+}
+
+int32_t bls_aggregate_sigs( const char* sigs, uint32_t sigs_len, const char* agg, uint32_t agg_len) {
+   return intrinsics::get().call<intrinsics::bls_aggregate_sigs>(sigs, sigs_len, agg, agg_len );
+}
+
+bool bls_aggregate_verify( const char* sig, uint32_t sig_len, const char* digs, uint32_t digs_len, char* pubs, uint32_t pubs_len) {
+   return intrinsics::get().call<intrinsics::bls_aggregate_verify>(sig, sig_len, digs, digs_len, pubs, pubs_len );
+}

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -4,6 +4,7 @@
 #include <eosio/chain.h>
 #include <eosio/crypto.h>
 #include <eosio/crypto_ext.h>
+#include <eosio/crypto_bls_ext.h>
 #include <eosio/db.h>
 #include <eosio/permission.h>
 #include <eosio/print.h>
@@ -171,8 +172,11 @@ intrinsic_macro(k1_recover) \
 intrinsic_macro(alt_bn128_add) \
 intrinsic_macro(alt_bn128_mul) \
 intrinsic_macro(alt_bn128_pair) \
-intrinsic_macro(mod_exp)
-
+intrinsic_macro(mod_exp) \
+intrinsic_macro(bls_verify)  \
+intrinsic_macro(bls_aggregate_pubkeys)  \
+intrinsic_macro(bls_aggregate_sigs)  \
+intrinsic_macro(bls_aggregate_verify) 
 
 
 #define CREATE_ENUM(name) \

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -467,7 +467,11 @@ struct generation_utils {
          {"capi_checksum512", "checksum512"},
          {"fixed_bytes_20", "checksum160"},
          {"fixed_bytes_32", "checksum256"},
-         {"fixed_bytes_64", "checksum512"}
+         {"fixed_bytes_64", "checksum512"},
+
+         {"capi_bls_public_key", "bls_public_key"},
+         {"capi_bls_signature", "bls_signature"}
+
       };
 
       auto ret = translation_table[t];
@@ -759,6 +763,8 @@ struct generation_utils {
          "signature",
          "public_key",
          "signature",
+         "bls_public_key",
+         "bls_signature",
          "symbol",
          "symbol_code",
          "asset",


### PR DESCRIPTION
## Change Description

This pull request introduces aggregate signatures (BLS signature scheme) as a protocol feature. It uses Chia's BLS-signatures library, which in turn depends on the Relic toolkit.

Dependent on https://github.com/AntelopeIO/leap/pull/661

## API Changes

It defines the following new host functions : 

bls_verify
bls_aggregate_pubkeys
bls_aggregate_sigs
bls_aggregate_verify

as well as new built-in types :

bls_public_key
bls_signature

Unit tests are included in libraries/libfc/test/test_bls.cpp

## Documentation Additions

Documentation of the new features will be provided on demand
