### PR TITLE
Resolve #97: Allow `name` typed primary keys

### DIFF
--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -439,6 +439,8 @@ class multi_index
 {
    private:
 
+      static_assert( std::is_same_v<decltype(_multi_index_detail::primary_key_cast(std::declval<T>().primary_key())), uint64_t>,
+                     "Primary key must be uint64_t or name" );
       static_assert( sizeof...(Indices) <= 16, "multi_index only supports a maximum of 16 secondary indices" );
 
       constexpr static bool validate_table_name( name n ) {
@@ -1273,8 +1275,10 @@ class multi_index
        * EOSIO_DISPATCH( addressbook, (myaction) )
        * @endcode
        */
-      const_iterator lower_bound( uint64_t primary )const {
-         auto itr = internal_use_do_not_use::db_lowerbound_i64( _code.value, _scope, static_cast<uint64_t>(TableName), primary );
+      template<typename PK>
+      const_iterator lower_bound( PK primary )const {
+         uint64_t primary_int = _multi_index_detail::primary_key_cast(primary);
+         auto itr = internal_use_do_not_use::db_lowerbound_i64( _code.value, _scope, static_cast<uint64_t>(TableName), primary_int );
          if( itr < 0 ) return end();
          const auto& obj = load_object_by_primary_iterator( itr );
          return {this, &obj};
@@ -1317,8 +1321,10 @@ class multi_index
        * EOSIO_DISPATCH( addressbook, (myaction) )
        * @endcode
        */
-      const_iterator upper_bound( uint64_t primary )const {
-         auto itr = internal_use_do_not_use::db_upperbound_i64( _code.value, _scope, static_cast<uint64_t>(TableName), primary );
+      template<typename PK>
+      const_iterator upper_bound( PK primary )const {
+         uint64_t primary_int = _multi_index_detail::primary_key_cast(primary);
+         auto itr = internal_use_do_not_use::db_upperbound_i64( _code.value, _scope, static_cast<uint64_t>(TableName), primary_int );
          if( itr < 0 ) return end();
          const auto& obj = load_object_by_primary_iterator( itr );
          return {this, &obj};
@@ -1776,7 +1782,8 @@ class multi_index
        * The most common mistake is when the local variable is defined as auto 
        * typename, instead it should be of type auto& or decltype(auto).
        */
-      const T& get( uint64_t primary, const char* error_msg = "unable to find key" )const {
+      template<typename PK>
+      const T& get( PK primary, const char* error_msg = "unable to find key" )const {
          auto result = find( primary );
          eosio::check( result != cend(), error_msg );
          return *result;
@@ -1805,14 +1812,16 @@ class multi_index
        * EOSIO_DISPATCH( addressbook, (myaction) )
        * @endcode
        */
-      const_iterator find( uint64_t primary )const {
+      template<typename PK>
+      const_iterator find( PK primary )const {
          auto itr2 = std::find_if(_items_vector.rbegin(), _items_vector.rend(), [&](const item_ptr& ptr) {
-            return _multi_index_detail::primary_key_cast(ptr._item->primary_key()) == primary;
+            return ptr._item->primary_key() == primary;
          });
          if( itr2 != _items_vector.rend() )
             return iterator_to(*(itr2->_item));
 
-         auto itr = internal_use_do_not_use::db_find_i64( _code.value, _scope, static_cast<uint64_t>(TableName), primary );
+         uint64_t primary_int = _multi_index_detail::primary_key_cast(primary);
+         auto itr = internal_use_do_not_use::db_find_i64( _code.value, _scope, static_cast<uint64_t>(TableName), primary_int );
          if( itr < 0 ) return end();
 
          const item& i = load_object_by_primary_iterator( itr );
@@ -1828,14 +1837,16 @@ class multi_index
        * @return An iterator to the found object which has a primary key equal to `primary` OR throws an exception if an object with primary key `primary` is not found.
        */
 
-      const_iterator require_find( uint64_t primary, const char* error_msg = "unable to find key" )const {
+      template<typename PK>
+      const_iterator require_find( PK primary, const char* error_msg = "unable to find key" )const {
          auto itr2 = std::find_if(_items_vector.rbegin(), _items_vector.rend(), [&](const item_ptr& ptr) {
                return ptr._item->primary_key() == primary;
             });
          if( itr2 != _items_vector.rend() )
             return iterator_to(*(itr2->_item));
 
-         auto itr = internal_use_do_not_use::db_find_i64( _code.value, _scope, static_cast<uint64_t>(TableName), primary );
+         uint64_t primary_int = _multi_index_detail::primary_key_cast(primary);
+         auto itr = internal_use_do_not_use::db_find_i64( _code.value, _scope, static_cast<uint64_t>(TableName), primary_int );
          eosio::check( itr >= 0,  error_msg );
 
          const item& i = load_object_by_primary_iterator( itr );

--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -334,6 +334,10 @@ namespace _multi_index_detail {
       static constexpr eosio::fixed_bytes<32> true_lowest() { return eosio::fixed_bytes<32>(); }
    };
 
+   template<typename PK>
+   inline uint64_t primary_key_cast(PK pk) { return pk; }
+   inline uint64_t primary_key_cast(eosio::name pk) { return pk.value; }
+
 }
 
 /**
@@ -821,7 +825,7 @@ class multi_index
          });
 
          const item* ptr = itm.get();
-         auto pk   = itm->primary_key();
+         auto pk   = _multi_index_detail::primary_key_cast(itm->primary_key());
          auto pitr = itm->__primary_itr;
 
          _items_vector.emplace_back( std::move(itm), pk, pitr );
@@ -1574,7 +1578,7 @@ class multi_index
             datastream<char*> ds( (char*)buffer, size );
             ds << obj;
 
-            auto pk = obj.primary_key();
+            uint64_t pk = _multi_index_detail::primary_key_cast(obj.primary_key());
 
             i.__primary_itr = internal_use_do_not_use::db_store_i64( _scope, static_cast<uint64_t>(TableName), payer.value, pk, buffer, size );
 
@@ -1593,7 +1597,7 @@ class multi_index
          });
 
          const item* ptr = itm.get();
-         auto pk   = itm->primary_key();
+         auto pk   = _multi_index_detail::primary_key_cast(itm->primary_key());
          auto pitr = itm->__primary_itr;
 
          _items_vector.emplace_back( std::move(itm), pk, pitr );
@@ -1700,12 +1704,12 @@ class multi_index
 
          auto secondary_keys = make_extractor_tuple::get_extractor_tuple(_indices, obj);
 
-         auto pk = obj.primary_key();
+         uint64_t pk = _multi_index_detail::primary_key_cast(obj.primary_key());
 
          auto& mutableobj = const_cast<T&>(obj); // Do not forget the auto& otherwise it would make a copy and thus not update at all.
          updater( mutableobj );
 
-         eosio::check( pk == obj.primary_key(), "updater cannot change primary key when modifying an object" );
+         eosio::check( pk == _multi_index_detail::primary_key_cast(obj.primary_key()), "updater cannot change primary key when modifying an object" );
 
          size_t size = pack_size( obj );
          //using malloc/free here potentially is not exception-safe, although WASM doesn't support exceptions
@@ -1803,7 +1807,7 @@ class multi_index
        */
       const_iterator find( uint64_t primary )const {
          auto itr2 = std::find_if(_items_vector.rbegin(), _items_vector.rend(), [&](const item_ptr& ptr) {
-            return ptr._item->primary_key() == primary;
+            return _multi_index_detail::primary_key_cast(ptr._item->primary_key()) == primary;
          });
          if( itr2 != _items_vector.rend() )
             return iterator_to(*(itr2->_item));

--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -785,7 +785,7 @@ class multi_index
       class make_extractor_tuple {
          template <typename Obj, typename IndicesType, uint64_t... Seq>
          static constexpr auto get_type(const IndicesType& indices, const Obj& obj, std::index_sequence<Seq...>) {
-            return std::make_tuple(decltype(get<0>(std::get<Seq>(indices)))::extract_secondary_key(obj)...);
+            return std::make_tuple(decltype(std::get<0>(std::get<Seq>(indices)))::extract_secondary_key(obj)...);
          }
       public:
          template <typename Obj, typename IndicesType>

--- a/tests/integration/contracts.hpp.in
+++ b/tests/integration/contracts.hpp.in
@@ -27,5 +27,8 @@ namespace eosio::testing {
       static std::vector<char>    get_code_hash_write_test_abi() { return read_abi("${CMAKE_BINARY_DIR}/../unit/test_contracts/get_code_hash_write.abi"); }
       static std::vector<uint8_t> get_code_hash_read_test_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../unit/test_contracts/get_code_hash_read.wasm"); }
       static std::vector<char>    get_code_hash_read_test_abi() { return read_abi("${CMAKE_BINARY_DIR}/../unit/test_contracts/get_code_hash_read.abi"); }
+
+      static std::vector<uint8_t> name_pk_tests_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../unit/test_contracts/name_pk_tests.wasm"); }
+      static std::vector<char>    name_pk_tests_abi() { return read_abi("${CMAKE_BINARY_DIR}/../unit/test_contracts/name_pk_tests.abi"); }
    };
 } //ns eosio::testing

--- a/tests/integration/name_pk_tests.cpp
+++ b/tests/integration/name_pk_tests.cpp
@@ -1,0 +1,32 @@
+#include <boost/test/unit_test.hpp>
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+
+#include <Runtime/Runtime.h>
+
+#include <fc/variant_object.hpp>
+
+#include <contracts.hpp>
+
+using namespace eosio;
+using namespace eosio::testing;
+using namespace eosio::chain;
+using namespace fc;
+
+using mvo = fc::mutable_variant_object;
+
+BOOST_AUTO_TEST_SUITE(name_pk_tests_suite)
+
+BOOST_FIXTURE_TEST_CASE( name_pk_tests, tester ) try {
+   create_accounts( { "test"_n } );
+   produce_block();
+
+   set_code( "test"_n, contracts::name_pk_tests_wasm() );
+   set_abi( "test"_n,  contracts::name_pk_tests_abi().data() );
+
+   produce_blocks();
+   push_action("test"_n, "write"_n, "test"_n, mvo());
+   push_action("test"_n, "read"_n, "test"_n, mvo());
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/unit/test_contracts/CMakeLists.txt
+++ b/tests/unit/test_contracts/CMakeLists.txt
@@ -9,6 +9,7 @@ add_contract(minimal_tests minimal_tests minimal_tests.cpp)
 add_contract(crypto_primitives_tests crypto_primitives_tests crypto_primitives_tests.cpp)
 add_contract(get_code_hash_tests get_code_hash_write get_code_hash_write.cpp)
 add_contract(get_code_hash_tests get_code_hash_read get_code_hash_read.cpp)
+add_contract(name_pk_tests name_pk_tests name_pk_tests.cpp)
 add_contract(capi_tests capi_tests capi/capi.c capi/action.c capi/chain.c capi/crypto.c capi/db.c capi/permission.c
                                    capi/print.c capi/privileged.c capi/system.c capi/transaction.c)
 

--- a/tests/unit/test_contracts/explicit_nested_tests.cpp
+++ b/tests/unit/test_contracts/explicit_nested_tests.cpp
@@ -32,7 +32,7 @@ CONTRACT explicit_nested_tests : public contract {
       std::tuple<uint64_t, std::optional<float>, std::vector<int>> tup1;
       std::variant<uint64_t, std::optional<std::pair<int, float>>, std::vector<int>> var1;
       std::vector<std::vector<_mystruct>> vvmys;
-      auto primary_key() const { return id; }
+      auto primary_key() const -> decltype(id) { return id; }
 
       EOSLIB_SERIALIZE(testdata, (id)(data)(data_vec)(data_vec2)(data_vec3)(tup1)(var1)(vvmys));
    };

--- a/tests/unit/test_contracts/name_pk_tests.cpp
+++ b/tests/unit/test_contracts/name_pk_tests.cpp
@@ -1,0 +1,35 @@
+// Verifies that a table with name-typed primary key works
+
+#include <eosio/multi_index.hpp>
+#include <eosio/contract.hpp>
+
+struct [[eosio::table]] name_table {
+    eosio::name pk;
+    int num;
+
+    auto primary_key() const { return pk; }
+};
+using name_table_idx = eosio::multi_index<"name.pk"_n, name_table>;
+
+class [[eosio::contract]] name_pk_tests : public eosio::contract {
+ public:
+   using eosio::contract::contract;
+
+   [[eosio::action]] void write() {
+       name_table_idx table(get_self(), 0);
+       table.emplace(get_self(), [](auto& row) {
+           row.pk = "alice"_n;
+           row.num = 2;
+       });
+       table.emplace(get_self(), [](auto& row) {
+           row.pk = "bob"_n;
+           row.num = 1;
+       });
+   }
+
+   [[eosio::action]] void read() {
+       name_table_idx table(get_self(), 0);
+       eosio::check(table.get("alice"_n).num == 2, "num mismatch");
+       eosio::check(table.get("bob"_n).num == 1, "num mismatch");
+   }
+};


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Resolve #97 -- Using a `name` as a primary key in a table is such a common use case that even the core contracts do it extensively. Adding first class support for this use case to the `multi_index` template is trivial, and allows contract code to be more expressive.

## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
The `multi_index` API now supports usage of a `name` as a table primary key, and implicitly casts it down to an `int` for indexing.

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
