### PR TITLE
Resolve #99: Fix abigen with int expression template arguments

### DIFF
--- a/tests/toolchain/abigen-pass/tagged_number_test.abi
+++ b/tests/toolchain/abigen-pass/tagged_number_test.abi
@@ -1,0 +1,38 @@
+{
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT ",
+    "version": "eosio::abi/1.2",
+    "types": [],
+    "structs": [
+        {
+            "name": "TaggedNumber_3472950412842106880",
+            "base": "",
+            "fields": [
+                {
+                    "name": "value",
+                    "type": "uint64"
+                }
+            ]
+        },
+        {
+            "name": "test",
+            "base": "",
+            "fields": [
+                {
+                    "name": "",
+                    "type": "TaggedNumber_3472950412842106880"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "test",
+            "type": "test",
+            "ricardian_contract": ""
+        }
+    ],
+    "tables": [],
+    "ricardian_clauses": [],
+    "variants": [],
+    "action_results": []
+}

--- a/tests/toolchain/abigen-pass/tagged_number_test.cpp
+++ b/tests/toolchain/abigen-pass/tagged_number_test.cpp
@@ -1,0 +1,17 @@
+#include <eosio/eosio.hpp>
+
+using namespace eosio;
+
+template<uint64_t Tag>
+struct TaggedNumber {
+    uint64_t value;
+};
+
+class [[eosio::contract]] tagged_number_test : public contract {
+  public:
+      using contract::contract;
+      
+      [[eosio::action]]
+      void test(TaggedNumber<"a.tag"_n.value>) {
+      }
+};

--- a/tests/toolchain/abigen-pass/tagged_number_test.json
+++ b/tests/toolchain/abigen-pass/tagged_number_test.json
@@ -1,0 +1,9 @@
+{
+   "tests" : [
+      {
+         "expected" : {
+            "abi-file" : "tagged_number_test.abi"
+         }
+      }
+   ]
+}

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -370,7 +370,8 @@ struct generation_utils {
          if (auto ce = llvm::dyn_cast<clang::CastExpr>(std::get<clang::Expr*>(arg))) {
             auto il = llvm::dyn_cast<clang::IntegerLiteral>(ce->getSubExpr());
             return std::to_string(il->getValue().getLimitedValue());
-         }
+         } else if (auto ce = llvm::dyn_cast<clang::ConstantExpr>(std::get<clang::Expr*>(arg)))
+             return ce->getResultAsAPSInt().toString(10);
       } else {
          return std::get<llvm::APSInt>(arg).toString(10);
       }

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -370,8 +370,9 @@ struct generation_utils {
          if (auto ce = llvm::dyn_cast<clang::CastExpr>(std::get<clang::Expr*>(arg))) {
             auto il = llvm::dyn_cast<clang::IntegerLiteral>(ce->getSubExpr());
             return std::to_string(il->getValue().getLimitedValue());
-         } else if (auto ce = llvm::dyn_cast<clang::ConstantExpr>(std::get<clang::Expr*>(arg)))
+         } else if (auto ce = llvm::dyn_cast<clang::ConstantExpr>(std::get<clang::Expr*>(arg))) {
              return ce->getResultAsAPSInt().toString(10);
+         }
       } else {
          return std::get<llvm::APSInt>(arg).toString(10);
       }


### PR DESCRIPTION
## Change Description
Resolve #99
In my contracts, I use several template arguments which are expressions which resolve to integral values (such as an `eosio::name`) but are not literal integer values. This works great in my contracts, but causes abigen to fail.

This PReq fixes abigen in such cases where a template argument is an expression that resolves to an integer, but isn't an integer literal.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
