### PR TITLE
Fix some issues when building EOSIO contracts

### DIFF
--- a/tools/cc/cdt-cpp.cpp.in
+++ b/tools/cc/cdt-cpp.cpp.in
@@ -145,7 +145,7 @@ int main(int argc, const char **argv) {
                output = opts.output_fn.empty() ? "a.out" : opts.output_fn;
             } else {
                SmallString<64> res;
-               llvm::sys::fs::createTemporaryFile("eosio", ".o", res);
+               llvm::sys::fs::createTemporaryFile("antelope", ".o", res);
                output = res.c_str();
             }
 

--- a/tools/cc/cdt-cpp.cpp.in
+++ b/tools/cc/cdt-cpp.cpp.in
@@ -156,12 +156,12 @@ int main(int argc, const char **argv) {
             new_opts.insert(new_opts.begin(), {"-o", output});
             outputs.push_back(output);
          }
-         new_opts.insert(new_opts.begin(), input);
 
-         if (llvm::sys::path::extension(input).equals(".c"))
-            new_opts.insert(new_opts.begin(), "-xc++");
+         new_opts.insert(new_opts.begin(), "-");
 
-         if (!eosio::cdt::environment::exec_subprogram("clang-9", new_opts)) {
+         new_opts.insert(new_opts.begin(), "-xc++");
+
+         if (!eosio::cdt::environment::exec_subprogram("clang-9", new_opts, false, input)) {
             llvm::sys::fs::remove(tmp_file);
             return -1;
          }

--- a/tools/cc/cdt-cpp.cpp.in
+++ b/tools/cc/cdt-cpp.cpp.in
@@ -126,9 +126,6 @@ int main(int argc, const char **argv) {
    try {
       for (auto input : opts.inputs) {
          std::vector<std::string> new_opts = opts.comp_options;
-         SmallString<64> res;
-         llvm::sys::path::system_temp_directory(true, res);
-         std::string tmp_file = std::string(res.c_str())+"/"+llvm::sys::path::filename(input).str();
          std::string output;
 
          if (!opts.pp_only) {
@@ -144,28 +141,40 @@ int main(int argc, const char **argv) {
             std::string source_path = src.str().empty() ? "." : src.str();
             new_opts.insert(new_opts.begin(), "-I" + source_path);
 
-            if (llvm::sys::fs::exists(tmp_file)) {
-               input = tmp_file;
-            }
-            output = tmp_file+".o";
-
             if (!opts.link) {
                output = opts.output_fn.empty() ? "a.out" : opts.output_fn;
+            } else {
+               SmallString<64> res;
+               llvm::sys::fs::createTemporaryFile("eosio", ".o", res);
+               output = res.c_str();
             }
 
             new_opts.insert(new_opts.begin(), {"-o", output});
             outputs.push_back(output);
          }
 
-         new_opts.insert(new_opts.begin(), "-");
+         llvm::Optional<std::string> stdin_redirect;
+         llvm::SmallString<64> abs_input(input.c_str());
+         llvm::sys::fs::make_absolute(abs_input);
+         auto file_iter = codegen::get().tmp_files.find(abs_input.c_str());
+         if (file_iter != codegen::get().tmp_files.end()) {
+            stdin_redirect = file_iter->second;
+            new_opts.insert(new_opts.begin(), "-");
+         } else {
+            new_opts.insert(new_opts.begin(), input);
+         }
 
          new_opts.insert(new_opts.begin(), "-xc++");
 
-         if (!eosio::cdt::environment::exec_subprogram("clang-9", new_opts, false, input)) {
-            llvm::sys::fs::remove(tmp_file);
+         if (!eosio::cdt::environment::exec_subprogram("clang-9", new_opts, false, stdin_redirect)) {
+            if(stdin_redirect) {
+               llvm::sys::fs::remove(*stdin_redirect);
+            }
             return -1;
          }
-         llvm::sys::fs::remove(tmp_file);
+         if(stdin_redirect) {
+            llvm::sys::fs::remove(*stdin_redirect);
+         }
       }
    } catch (std::runtime_error& err) {
       llvm::errs() << err.what() << '\n';

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -870,8 +870,10 @@ static Options CreateOptions(bool add_defaults=true) {
          replace_extension(fn);
          output_fn = fn.str();
       } else {
-         ldopts.emplace_back("a.out");
+         output_fn = "a.out";
       }
+      ldopts.emplace_back("-o");
+      ldopts.emplace_back(output_fn);
 #else
       if (inputs.size() == 1) {
          llvm::SmallString<256> fn = llvm::sys::path::filename(inputs[0]);

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -702,7 +702,7 @@ static Options CreateOptions(bool add_defaults=true) {
       copts.emplace_back("-MMD");
    }
    if (!MT_opt.empty()) {
-      copts.emplace_back("-MT "+MT_opt);
+      copts.insert(copts.end(), { "-MT", MT_opt });
    }
    if (finline_functions_opt) {
       copts.emplace_back("-finline-functions");

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -469,13 +469,11 @@ namespace eosio { namespace cdt {
                   return;
                }
 
-               int fd;
                llvm::SmallString<128> fn;
                try {
-                  SmallString<64> res;
-                  llvm::sys::path::system_temp_directory(true, res);
+                  llvm::sys::fs::createTemporaryFile("eosio", ".cpp", fn);
 
-                  std::ofstream out(std::string(res.c_str())+"/"+llvm::sys::path::filename(main_fe->getName()).str());
+                  std::ofstream out(fn.c_str());
                   {
                      llvm::SmallString<64> abs_file_path(main_fe->getName());
                      llvm::sys::fs::make_absolute(abs_file_path);

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -471,7 +471,7 @@ namespace eosio { namespace cdt {
 
                llvm::SmallString<128> fn;
                try {
-                  llvm::sys::fs::createTemporaryFile("eosio", ".cpp", fn);
+                  llvm::sys::fs::createTemporaryFile("antelope", ".cpp", fn);
 
                   std::ofstream out(fn.c_str());
                   {

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -88,7 +88,7 @@ namespace eosio { namespace cdt {
          codegen& cg = codegen::get();
          FileID    main_fid;
          StringRef main_name;
-         Rewriter  rewriter;
+         std::stringstream ss;
          CompilerInstance* ci;
          bool apply_was_found = false;
 
@@ -107,7 +107,6 @@ namespace eosio { namespace cdt {
                : generation_utils(), ci(CI) {
             cg.ast_context = &(CI->getASTContext());
             cg.codegen_ci = CI;
-            rewriter.setSourceMgr(CI->getASTContext().getSourceManager(), CI->getASTContext().getLangOpts());
             get_error_emitter().set_compiler_instance(CI);
          }
 
@@ -119,9 +118,7 @@ namespace eosio { namespace cdt {
             main_name = mn;
          }
 
-         Rewriter& get_rewriter() {
-            return rewriter;
-         }
+         auto& get_ss() { return ss; }
 
          bool is_datastream(const QualType& qt) {
             auto str_name = qt.getAsString();
@@ -151,7 +148,6 @@ namespace eosio { namespace cdt {
          template <typename F>
          void create_dispatch(const std::string& attr, const std::string& func_name, F&& get_str, CXXMethodDecl* decl) {
             constexpr static uint32_t max_stack_size = 512;
-            std::stringstream ss;
             codegen& cg = codegen::get();
             std::string nm = decl->getNameAsString()+"_"+decl->getParent()->getNameAsString();
             if (cg.is_eosio_contract(decl, cg.contract_name)) {
@@ -212,7 +208,6 @@ namespace eosio { namespace cdt {
                }
                ss << "}}\n";
 
-               rewriter.InsertTextAfter(ci->getSourceManager().getLocForEndOfFile(main_fid), ss.str());
             }
          }
 
@@ -481,9 +476,10 @@ namespace eosio { namespace cdt {
                   llvm::sys::path::system_temp_directory(true, res);
 
                   std::ofstream out(std::string(res.c_str())+"/"+llvm::sys::path::filename(main_fe->getName()).str());
-                  for (auto inc : global_includes[main_file]) {
-                     visitor->get_rewriter().ReplaceText(inc.range,
-                           std::string("\"")+inc.file_name+"\"\n");
+                  {
+                     llvm::SmallString<64> abs_file_path(main_fe->getName());
+                     llvm::sys::fs::make_absolute(abs_file_path);
+                     out << "#include \"" << abs_file_path.c_str() << "\"\n";
                   }
                   const auto& quoted = [](const std::string& s) {
                      std::stringstream ss;
@@ -496,7 +492,7 @@ namespace eosio { namespace cdt {
                   };
 
                   // generate apply stub with abi
-                  std::stringstream ss;
+                  std::stringstream& ss = visitor->get_ss();
                   ss << "\n";
                   ss << "extern \"C\" {\n";
                   ss << "__attribute__((eosio_wasm_import))\n";
@@ -508,9 +504,8 @@ namespace eosio { namespace cdt {
                   ss << "eosio_assert_code(false, 1);";
                   ss << "}\n";
                   ss << "}";
-                  visitor->get_rewriter().InsertTextAfter(ci->getSourceManager().getLocForEndOfFile(fid), ss.str());
-                  auto& RewriteBuf = visitor->get_rewriter().getEditBuffer(fid);
-                  out << std::string(RewriteBuf.begin(), RewriteBuf.end());
+
+                  out << ss.rdbuf();
                   cg.tmp_files.emplace(main_file, fn.str());
                   out.close();
                } catch (...) {

--- a/tools/include/eosio/utils.hpp
+++ b/tools/include/eosio/utils.hpp
@@ -132,7 +132,8 @@ struct environment {
        }
      return env_table;
    }
-   static bool exec_subprogram(const std::string prog, std::vector<std::string> options, bool root=false) {
+   static bool exec_subprogram(const std::string prog, std::vector<std::string> options, bool root=false,
+                               llvm::Optional<std::string> stdin_file = llvm::None) {
       std::vector<llvm::StringRef> args;
       args.push_back(prog);
       args.insert(args.end(), options.begin(), options.end());
@@ -140,7 +141,11 @@ struct environment {
       if (root)
          find_path = "/usr/bin";
       if ( const auto& path = llvm::sys::findProgramByName(prog.c_str(), {find_path}) ) {
-         return llvm::sys::ExecuteAndWait(*path, args, {}, {}, 0, 0, nullptr, nullptr) == 0;
+         std::vector<llvm::Optional<llvm::StringRef>> redirects;
+         if(stdin_file) {
+            redirects = { llvm::StringRef{*stdin_file}, llvm::None, llvm::None };
+         }
+         return llvm::sys::ExecuteAndWait(*path, args, {}, redirects, 0, 0, nullptr, nullptr) == 0;
       }
       else
          return false;


### PR DESCRIPTION
This is a backport of EOSIO/eosio.cdt#968 / EOSIO/eosio.cdt#1070 that resolves EOSIO/eosio.cdt#742. 

> * Fix dependency file generation (-MD/-MMD) to hold the original source and not the generated temporary file.
> * Make temporary filenames unique to avoid races in parallel builds.