### PR TITLE
Add extended_asset operators and unit tests.

### DIFF
--- a/libraries/eosiolib/core/eosio/asset.hpp
+++ b/libraries/eosiolib/core/eosio/asset.hpp
@@ -462,30 +462,69 @@ namespace eosio {
          return a;
       }
 
+      /// Multiplication operator.
+      extended_asset& operator*=( int64_t b ) {
+         quantity *= b;
+         return *this;
+      }
+
+      /// Multiplication operator.
+      friend extended_asset operator*( const extended_asset& a, int64_t b ) {
+         return {a.quantity * b, a.contract};
+      }
+
+      /// Multiplication operator.
+      friend extended_asset operator*( int64_t a, const extended_asset& b ) {
+         return {a * b.quantity, b.contract};
+      }
+
+      /// Division operator. Follows format of 'int64_t operator/( const asset& a, const asset& b )'.
+      friend int64_t operator/( const extended_asset& a, const extended_asset& b ) {
+         eosio::check( a.contract == b.contract, "type mismatch" );
+         return a.quantity / b.quantity;
+      }
+
+      /// Division operator.
+      extended_asset& operator/=( int64_t b ) {
+         quantity /= b;
+         return *this;
+      }
+
+      /// Division operator.
+      friend extended_asset operator/( const extended_asset& a, int64_t b ) {
+         return {a.quantity / b, a.contract};
+      }
+
+
       /// Less than operator
       friend bool operator<( const extended_asset& a, const extended_asset& b ) {
          eosio::check( a.contract == b.contract, "type mismatch" );
          return a.quantity < b.quantity;
       }
 
+      /// Greater than operator
+      friend bool operator>( const extended_asset& a, const extended_asset& b ) {
+         eosio::check( a.contract == b.contract, "type mismatch" );
+         return a.quantity > b.quantity;
+      }
 
-      /// Comparison operator
+      /// Equality operator
       friend bool operator==( const extended_asset& a, const extended_asset& b ) {
          return std::tie(a.quantity, a.contract) == std::tie(b.quantity, b.contract);
       }
 
-      /// Comparison operator
+      /// Inequality operator
       friend bool operator!=( const extended_asset& a, const extended_asset& b ) {
          return std::tie(a.quantity, a.contract) != std::tie(b.quantity, b.contract);
       }
 
-      /// Comparison operator
+      /// Less than or equal operator
       friend bool operator<=( const extended_asset& a, const extended_asset& b ) {
          eosio::check( a.contract == b.contract, "type mismatch" );
          return a.quantity <= b.quantity;
       }
 
-      /// Comparison operator
+      /// Greater than or equal operator
       friend bool operator>=( const extended_asset& a, const extended_asset& b ) {
          eosio::check( a.contract == b.contract, "type mismatch" );
          return a.quantity >= b.quantity;

--- a/tests/unit/asset_tests.cpp
+++ b/tests/unit/asset_tests.cpp
@@ -491,6 +491,84 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
       })
    )
 
+   // --------------------------------------------------------------------------
+   // extended_asset& operator*=( int64_t b )
+   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} *=  0LL ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( (extended_asset{ asset{ 2LL, sym_no_prec}, {}} *=  1LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( (extended_asset{ asset{ 2LL, sym_no_prec}, {}} *= -1LL ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) );
+
+   CHECK_ASSERT( "multiplication underflow", (
+      [&]() {
+         extended_asset{ asset{asset_min, sym_no_prec}, {}} *= 2LL;
+      })
+   )
+
+   CHECK_ASSERT( "multiplication overflow", (
+      [&]() {
+         extended_asset{ asset{ asset_max, sym_no_prec}, {}} *= 2LL;
+      })
+   )
+
+   // --------------------------------------------------------------------------
+   // friend extended_asset operator*( const extended_asset& a, int64_t b )
+   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} *  0LL ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( (extended_asset{ asset{ 2LL, sym_no_prec}, {}} *  1LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( (extended_asset{ asset{ 2LL, sym_no_prec}, {}} * -1LL ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) );
+
+   CHECK_ASSERT( "multiplication underflow", (
+      [&]() {
+         extended_asset{ asset{asset_min, sym_no_prec}, {}} * 2LL;
+      })
+   )
+
+   CHECK_ASSERT( "multiplication overflow", (
+      [&]() {
+         extended_asset{ asset{ asset_max, sym_no_prec}, {}} * 2LL;
+      })
+   )
+
+   // --------------------------------------------------------------------------
+   // friend extended_asset operator*( int64_t a, const extended_asset& b )
+   CHECK_EQUAL( ( 0LL * extended_asset{ asset{ 0LL, sym_no_prec}, {}} ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( ( 1LL * extended_asset{ asset{ 2LL, sym_no_prec}, {}} ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( (-1LL * extended_asset{ asset{ 2LL, sym_no_prec}, {}} ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) );
+
+   CHECK_ASSERT( "multiplication underflow", (
+      [&]() {
+         2LL * extended_asset{ asset{asset_min, sym_no_prec}, {}};
+      })
+   )
+
+   CHECK_ASSERT( "multiplication overflow", (
+      [&]() {
+         2LL * extended_asset{ asset{ asset_max, sym_no_prec}, {}};
+      })
+   )
+
+   // --------------------------------------------------------------------------
+   // friend int64_t operator/( const extended_asset& a, const extended_asset& b )
+   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} / extended_asset{ asset{ 1LL, sym_no_prec}, {}}), 0LL )
+   CHECK_EQUAL( (extended_asset{ asset{ 1LL, sym_no_prec}, {}} / extended_asset{ asset{ 1LL, sym_no_prec}, {}}), 1LL )
+   CHECK_EQUAL( (extended_asset{ asset{ 4LL, sym_no_prec}, {}} / extended_asset{ asset{ 2LL, sym_no_prec}, {}}), 2LL )
+   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} / extended_asset{ asset{ 2LL, sym_no_prec}, {}}), -2LL )
+   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} / extended_asset{ asset{-2LL, sym_no_prec}, {}}), 2LL )
+
+   // --------------------------------------------------------------------------
+   // friend extended_asset& operator/=( extended_asset& a, int64_t b )
+   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} /= 1LL ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ asset{ 1LL, sym_no_prec}, {}} /= 1LL ), (extended_asset{ asset{ 1LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ asset{ 4LL, sym_no_prec}, {}} /= 2LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} /= 2LL ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} /= -2LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) )
+
+   // --------------------------------------------------------------------------
+   // friend extended_asset operator/( const extended_asset& a, int64_t b )
+   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} / 1LL ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ asset{ 1LL, sym_no_prec}, {}} / 1LL ), (extended_asset{ asset{ 1LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ asset{ 4LL, sym_no_prec}, {}} / 2LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} / 2LL ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} / -2LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) )
+
    // --------------------------------------------------------------------
    // friend bool operator==(const extended_asset&, const extended_asset&)
    CHECK_EQUAL( (extended_asset{asset_no_prec, {}} == extended_asset{asset_no_prec, {}}), true )
@@ -508,6 +586,16 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
    CHECK_ASSERT( "type mismatch", (
       [&]() {
          bool b{extended_asset{{}, name{}} < extended_asset{{}, name{"eosioaccountj"}}};
+         return b;
+      })
+   )
+
+   // -------------------------------------------------------------------
+   // friend bool operator>(const extended_asset&, const extended_asset&)
+   CHECK_EQUAL( (extended_asset{asset{ 1LL, sym_no_prec}, {}} > extended_asset{asset_no_prec, name{}}), true )
+   CHECK_ASSERT( "type mismatch", (
+      [&]() {
+         bool b{extended_asset{{}, name{}} > extended_asset{{}, name{"eosioaccountj"}}};
          return b;
       })
    )

--- a/tests/unit/asset_tests.cpp
+++ b/tests/unit/asset_tests.cpp
@@ -364,7 +364,16 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
    static constexpr extended_symbol ext_sym_no_prec{sym_no_prec, name{"eosioaccountj"}};
    static constexpr extended_symbol ext_sym_prec{sym_prec, name{"eosioaccountj"}};
 
-   static const asset asset_no_prec{0LL, sym_no_prec};
+   // Assets with sym_no_prec
+   static const auto a0 = asset{ 0LL, sym_no_prec}; // AKA asset_no_prec
+   static const auto a1 = asset{ 1LL, sym_no_prec};
+   static const auto a2 = asset{ 2LL, sym_no_prec};
+   static const auto a4 = asset{ 4LL, sym_no_prec};
+   static const auto aneg1 = asset{ -1LL, sym_no_prec};
+   static const auto aneg2 = asset{ -2LL, sym_no_prec};
+   static const auto aneg4 = asset{ -4LL, sym_no_prec};
+
+   // Assets with sym_prec
    static const asset asset_prec{0LL, sym_prec};
 
    //// extended_asset()
@@ -372,12 +381,12 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
    CHECK_EQUAL( extended_asset{}.contract, name{}  )
 
    //// extended_asset(int64_t, extended_symbol)
-   CHECK_EQUAL( (extended_asset{{},ext_sym_no_prec}.quantity), (asset{0LL, sym_no_prec}) )
+   CHECK_EQUAL( (extended_asset{{},ext_sym_no_prec}.quantity), (a0) )
    CHECK_EQUAL( (extended_asset{{},ext_sym_no_prec}.contract), (name{"eosioaccountj"}) )
 
    //// extended_asset(asset, name)
-   CHECK_EQUAL( (extended_asset{asset_no_prec, name{"eosioaccountj"}}.quantity), (asset{ 0LL, sym_no_prec}) )
-   CHECK_EQUAL( (extended_asset{asset_no_prec, name{"eosioaccountj"}}.contract), (name{"eosioaccountj"}) )
+   CHECK_EQUAL( (extended_asset{a0, name{"eosioaccountj"}}.quantity), (a0) )
+   CHECK_EQUAL( (extended_asset{a0, name{"eosioaccountj"}}.contract), (name{"eosioaccountj"}) )
 
    // ------------------------------------------
    // extended_symbol get_extended_symbol()const
@@ -426,13 +435,13 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
 
    // -------------------------------
    // extended_asset operator-()const
-   CHECK_EQUAL( (-extended_asset{asset{ 0, sym_no_prec}, {}}.quantity), (extended_asset{asset_no_prec, {}}.quantity) )
-   CHECK_EQUAL( (-extended_asset{asset{-0, sym_no_prec}, {}}.quantity), (extended_asset{asset_no_prec, {}}.quantity) )
+   CHECK_EQUAL( (-extended_asset{asset{ 0, sym_no_prec}, {}}.quantity), (extended_asset{a0, {}}.quantity) )
+   CHECK_EQUAL( (-extended_asset{asset{-0, sym_no_prec}, {}}.quantity), (extended_asset{a0, {}}.quantity) )
    CHECK_EQUAL( (-extended_asset{asset{ 0, sym_prec}, {}}.quantity), (extended_asset{asset_prec, {}}.quantity) )
    CHECK_EQUAL( (-extended_asset{asset{-0, sym_prec}, {}}.quantity), (extended_asset{asset_prec, {}}.quantity) )
 
-   CHECK_EQUAL( (-extended_asset{asset{1LL, sym_no_prec}, {}}.quantity), (extended_asset{asset{-1LL, sym_no_prec}, {}}.quantity) )
-   CHECK_EQUAL( (-extended_asset{asset{1LL, sym_no_prec}, {}}.quantity), (extended_asset{asset{-1LL, sym_no_prec}, {}}.quantity) )
+   CHECK_EQUAL( (-extended_asset{a1, {}}.quantity), (extended_asset{aneg1, {}}.quantity) )
+   CHECK_EQUAL( (-extended_asset{a1, {}}.quantity), (extended_asset{aneg1, {}}.quantity) )
    CHECK_EQUAL( (-extended_asset{asset{1LL, sym_prec}, {}}.quantity), (extended_asset{asset{-1LL, sym_prec}, {}}.quantity) )
    CHECK_EQUAL( (-extended_asset{asset{1LL, sym_prec}, {}}.quantity), (extended_asset{asset{-1LL, sym_prec}, {}}.quantity) )
 
@@ -443,59 +452,59 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
 
    // -----------------------------------------------------------------------------
    // friend extended_asset operator+(const extended_asset&, const extended_asset&)
-   CHECK_EQUAL( (extended_asset{asset{0LL, sym_no_prec}, {}} + extended_asset{asset{ 0LL, sym_no_prec}, {}}), (extended_asset{asset_no_prec, {}}) )
-   CHECK_EQUAL( (extended_asset{asset{1LL, sym_no_prec}, {}} + extended_asset{asset{-1LL, sym_no_prec}, {}}), (extended_asset{asset_no_prec, {}}) )
+   CHECK_EQUAL( (extended_asset{a0, {}} + extended_asset{a0, {}}), (extended_asset{a0, {}}) )
+   CHECK_EQUAL( (extended_asset{a1, {}} + extended_asset{aneg1, {}}), (extended_asset{a0, {}}) )
 
    CHECK_ASSERT( "type mismatch", (
       [&]() {
-         extended_asset{asset_no_prec, name{"eosioaccountj"}} + extended_asset{asset_no_prec, name{"jtnuoccaoisoe"}};
+         extended_asset{a0, name{"eosioaccountj"}} + extended_asset{a0, name{"jtnuoccaoisoe"}};
       })
    )
 
    // -------------------------------------------------------------------------
    // friend extended_asset& operator+=(extended_asset&, const extended_asset&)
-   extended_asset temp{asset_no_prec, {}};
-   CHECK_EQUAL( (temp += temp), (extended_asset{asset_no_prec, {}}) )
-   temp = extended_asset{asset{1LL, sym_no_prec}, {}};
-   CHECK_EQUAL( (temp += extended_asset{asset{-1LL, sym_no_prec}, {}}), (extended_asset{asset_no_prec, {}}) )
+   extended_asset temp{a0, {}};
+   CHECK_EQUAL( (temp += temp), (extended_asset{a0, {}}) )
+   temp = extended_asset{a1, {}};
+   CHECK_EQUAL( (temp += extended_asset{aneg1, {}}), (extended_asset{a0, {}}) )
 
    CHECK_ASSERT( "type mismatch", (
       [&]() {
-         temp += extended_asset{asset_no_prec, name{"eosioaccountj"}};
+         temp += extended_asset{a0, name{"eosioaccountj"}};
       })
    )
 
    // -----------------------------------------------------------------------------
    // friend extended_asset operator-(const extended_asset&, const extended_asset&)
-   CHECK_EQUAL( (extended_asset{asset_no_prec, {}} - extended_asset{asset_no_prec, {}}),
-                  (extended_asset{asset_no_prec, {}}) )
-   CHECK_EQUAL( (extended_asset{asset{1LL, sym_no_prec}, {}} - extended_asset{asset{1LL, sym_no_prec}, {}}),
-                  (extended_asset{asset{asset_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{a0, {}} - extended_asset{a0, {}}),
+                  (extended_asset{a0, {}}) )
+   CHECK_EQUAL( (extended_asset{a1, {}} - extended_asset{a1, {}}),
+                  (extended_asset{asset{a0}, {}}) )
 
    CHECK_ASSERT( "type mismatch", (
       [&]() {
-         extended_asset{asset_no_prec, name{"eosioaccountj"}} - extended_asset{asset_no_prec, name{"jtnuoccaoisoe"}};
+         extended_asset{a0, name{"eosioaccountj"}} - extended_asset{a0, name{"jtnuoccaoisoe"}};
       })
    )
 
    // --------------------------------------------------------------------------
    // friend extended_asset& operator-=(extended_asset&, const extended_asset&)
-   temp = extended_asset{asset_no_prec, {}};
-   CHECK_EQUAL( (temp -= temp), (extended_asset{asset_no_prec, {}}) )
-   temp = extended_asset{asset{1LL, sym_no_prec}, {}};
-   CHECK_EQUAL( (temp -= temp), (extended_asset{asset_no_prec, {}}) )
+   temp = extended_asset{a0, {}};
+   CHECK_EQUAL( (temp -= temp), (extended_asset{a0, {}}) )
+   temp = extended_asset{a1, {}};
+   CHECK_EQUAL( (temp -= temp), (extended_asset{a0, {}}) )
 
    CHECK_ASSERT( "type mismatch", (
       [&]() {
-         temp -= extended_asset{asset_no_prec, name{"jtnuoccaoisoe"}};
+         temp -= extended_asset{a0, name{"jtnuoccaoisoe"}};
       })
    )
 
    // --------------------------------------------------------------------------
    // extended_asset& operator*=( int64_t b )
-   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} *=  0LL ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) );
-   CHECK_EQUAL( (extended_asset{ asset{ 2LL, sym_no_prec}, {}} *=  1LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) );
-   CHECK_EQUAL( (extended_asset{ asset{ 2LL, sym_no_prec}, {}} *= -1LL ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( (extended_asset{ a0, {}} *=  0LL ), (extended_asset{ a0, {}}) );
+   CHECK_EQUAL( (extended_asset{ a2, {}} *=  1LL ), (extended_asset{ a2, {}}) );
+   CHECK_EQUAL( (extended_asset{ a2, {}} *= -1LL ), (extended_asset{ aneg2, {}}) );
 
    CHECK_ASSERT( "multiplication underflow", (
       [&]() {
@@ -511,9 +520,9 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
 
    // --------------------------------------------------------------------------
    // friend extended_asset operator*( const extended_asset& a, int64_t b )
-   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} *  0LL ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) );
-   CHECK_EQUAL( (extended_asset{ asset{ 2LL, sym_no_prec}, {}} *  1LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) );
-   CHECK_EQUAL( (extended_asset{ asset{ 2LL, sym_no_prec}, {}} * -1LL ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( (extended_asset{ a0, {}} *  0LL ), (extended_asset{ a0, {}}) );
+   CHECK_EQUAL( (extended_asset{ a2, {}} *  1LL ), (extended_asset{ a2, {}}) );
+   CHECK_EQUAL( (extended_asset{ a2, {}} * -1LL ), (extended_asset{ aneg2, {}}) );
 
    CHECK_ASSERT( "multiplication underflow", (
       [&]() {
@@ -529,9 +538,9 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
 
    // --------------------------------------------------------------------------
    // friend extended_asset operator*( int64_t a, const extended_asset& b )
-   CHECK_EQUAL( ( 0LL * extended_asset{ asset{ 0LL, sym_no_prec}, {}} ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) );
-   CHECK_EQUAL( ( 1LL * extended_asset{ asset{ 2LL, sym_no_prec}, {}} ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) );
-   CHECK_EQUAL( (-1LL * extended_asset{ asset{ 2LL, sym_no_prec}, {}} ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) );
+   CHECK_EQUAL( ( 0LL * extended_asset{ a0, {}} ), (extended_asset{ a0, {}}) );
+   CHECK_EQUAL( ( 1LL * extended_asset{ a2, {}} ), (extended_asset{ a2, {}}) );
+   CHECK_EQUAL( (-1LL * extended_asset{ a2, {}} ), (extended_asset{ aneg2, {}}) );
 
    CHECK_ASSERT( "multiplication underflow", (
       [&]() {
@@ -547,42 +556,42 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
 
    // --------------------------------------------------------------------------
    // friend int64_t operator/( const extended_asset& a, const extended_asset& b )
-   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} / extended_asset{ asset{ 1LL, sym_no_prec}, {}}), 0LL )
-   CHECK_EQUAL( (extended_asset{ asset{ 1LL, sym_no_prec}, {}} / extended_asset{ asset{ 1LL, sym_no_prec}, {}}), 1LL )
-   CHECK_EQUAL( (extended_asset{ asset{ 4LL, sym_no_prec}, {}} / extended_asset{ asset{ 2LL, sym_no_prec}, {}}), 2LL )
-   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} / extended_asset{ asset{ 2LL, sym_no_prec}, {}}), -2LL )
-   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} / extended_asset{ asset{-2LL, sym_no_prec}, {}}), 2LL )
+   CHECK_EQUAL( (extended_asset{ a0, {}} / extended_asset{ a1, {}}), 0LL )
+   CHECK_EQUAL( (extended_asset{ a1, {}} / extended_asset{ a1, {}}), 1LL )
+   CHECK_EQUAL( (extended_asset{ a4, {}} / extended_asset{ a2, {}}), 2LL )
+   CHECK_EQUAL( (extended_asset{ aneg4, {}} / extended_asset{ a2, {}}), -2LL )
+   CHECK_EQUAL( (extended_asset{ aneg4, {}} / extended_asset{ aneg2, {}}), 2LL )
 
    // --------------------------------------------------------------------------
    // friend extended_asset& operator/=( extended_asset& a, int64_t b )
-   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} /= 1LL ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) )
-   CHECK_EQUAL( (extended_asset{ asset{ 1LL, sym_no_prec}, {}} /= 1LL ), (extended_asset{ asset{ 1LL, sym_no_prec}, {}}) )
-   CHECK_EQUAL( (extended_asset{ asset{ 4LL, sym_no_prec}, {}} /= 2LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) )
-   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} /= 2LL ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) )
-   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} /= -2LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ a0, {}} /= 1LL ), (extended_asset{ a0, {}}) )
+   CHECK_EQUAL( (extended_asset{ a1, {}} /= 1LL ), (extended_asset{ a1, {}}) )
+   CHECK_EQUAL( (extended_asset{ a4, {}} /= 2LL ), (extended_asset{ a2, {}}) )
+   CHECK_EQUAL( (extended_asset{ aneg4, {}} /= 2LL ), (extended_asset{ aneg2, {}}) )
+   CHECK_EQUAL( (extended_asset{ aneg4, {}} /= -2LL ), (extended_asset{ a2, {}}) )
 
    // --------------------------------------------------------------------------
    // friend extended_asset operator/( const extended_asset& a, int64_t b )
-   CHECK_EQUAL( (extended_asset{ asset{ 0LL, sym_no_prec}, {}} / 1LL ), (extended_asset{ asset{ 0LL, sym_no_prec}, {}}) )
-   CHECK_EQUAL( (extended_asset{ asset{ 1LL, sym_no_prec}, {}} / 1LL ), (extended_asset{ asset{ 1LL, sym_no_prec}, {}}) )
-   CHECK_EQUAL( (extended_asset{ asset{ 4LL, sym_no_prec}, {}} / 2LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) )
-   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} / 2LL ), (extended_asset{ asset{-2LL, sym_no_prec}, {}}) )
-   CHECK_EQUAL( (extended_asset{ asset{-4LL, sym_no_prec}, {}} / -2LL ), (extended_asset{ asset{ 2LL, sym_no_prec}, {}}) )
+   CHECK_EQUAL( (extended_asset{ a0, {}} / 1LL ), (extended_asset{ a0, {}}) )
+   CHECK_EQUAL( (extended_asset{ a1, {}} / 1LL ), (extended_asset{ a1, {}}) )
+   CHECK_EQUAL( (extended_asset{ a4, {}} / 2LL ), (extended_asset{ a2, {}}) )
+   CHECK_EQUAL( (extended_asset{ aneg4, {}} / 2LL ), (extended_asset{ aneg2, {}}) )
+   CHECK_EQUAL( (extended_asset{ aneg4, {}} / -2LL ), (extended_asset{ a2, {}}) )
 
    // --------------------------------------------------------------------
    // friend bool operator==(const extended_asset&, const extended_asset&)
-   CHECK_EQUAL( (extended_asset{asset_no_prec, {}} == extended_asset{asset_no_prec, {}}), true )
-   CHECK_EQUAL( (extended_asset{asset{1LL, sym_no_prec}, {}} == extended_asset{asset{1LL, sym_no_prec}, {}}), true )
+   CHECK_EQUAL( (extended_asset{a0, {}} == extended_asset{a0, {}}), true )
+   CHECK_EQUAL( (extended_asset{a1, {}} == extended_asset{a1, {}}), true )
 
    // --------------------------------------------------------------------
    // friend bool operator!=(const extended_asset&, const extended_asset&)
-   CHECK_EQUAL( (extended_asset{asset_no_prec, name{"eosioaccountj"}} != extended_asset{asset_no_prec, name{"jtnuoccaoisoe"}}), true )
-   CHECK_EQUAL( (extended_asset{asset{1LL, sym_no_prec}, {}} != extended_asset{asset{-1LL, sym_no_prec}, {}}), true )
-   CHECK_EQUAL( (extended_asset{asset{1LL, sym_no_prec}, {}} != extended_asset{asset{ 0LL, sym_no_prec}, name{"eosioaccountj"}}), true )
+   CHECK_EQUAL( (extended_asset{a0, name{"eosioaccountj"}} != extended_asset{a0, name{"jtnuoccaoisoe"}}), true )
+   CHECK_EQUAL( (extended_asset{a1, {}} != extended_asset{aneg1, {}}), true )
+   CHECK_EQUAL( (extended_asset{a1, {}} != extended_asset{a0, name{"eosioaccountj"}}), true )
 
    // -------------------------------------------------------------------
    // friend bool operator<(const extended_asset&, const extended_asset&)
-   CHECK_EQUAL( (extended_asset{asset_no_prec, name{}} < extended_asset{asset{ 1LL, sym_no_prec}, {}}), true )
+   CHECK_EQUAL( (extended_asset{a0, name{}} < extended_asset{a1, {}}), true )
    CHECK_ASSERT( "type mismatch", (
       [&]() {
          bool b{extended_asset{{}, name{}} < extended_asset{{}, name{"eosioaccountj"}}};
@@ -592,7 +601,7 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
 
    // -------------------------------------------------------------------
    // friend bool operator>(const extended_asset&, const extended_asset&)
-   CHECK_EQUAL( (extended_asset{asset{ 1LL, sym_no_prec}, {}} > extended_asset{asset_no_prec, name{}}), true )
+   CHECK_EQUAL( (extended_asset{a1, {}} > extended_asset{a0, name{}}), true )
    CHECK_ASSERT( "type mismatch", (
       [&]() {
          bool b{extended_asset{{}, name{}} > extended_asset{{}, name{"eosioaccountj"}}};
@@ -602,7 +611,7 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
 
    // --------------------------------------------------------------------
    // friend bool operator<=(const extended_asset&, const extended_asset&)
-   CHECK_EQUAL( (extended_asset{asset_no_prec, name{}} <= extended_asset{asset{ 1LL, sym_no_prec}, {}}), true );
+   CHECK_EQUAL( (extended_asset{a0, name{}} <= extended_asset{a1, {}}), true );
    CHECK_ASSERT( "type mismatch", (
       [&]() {
          bool b{extended_asset{{}, name{}} <= extended_asset{{}, name{"eosioaccountj"}}};
@@ -612,7 +621,7 @@ EOSIO_TEST_BEGIN(extended_asset_type_test)
 
    // --------------------------------------------------------------------
    // friend bool operator>=(const extended_asset&, const extended_asset&)
-   CHECK_EQUAL( (extended_asset{asset{ 1LL, sym_no_prec}, {}} >= extended_asset{asset_no_prec, name{}}), true );
+   CHECK_EQUAL( (extended_asset{a1, {}} >= extended_asset{a0, name{}}), true );
    CHECK_ASSERT( "type mismatch", (
       [&]() {
          bool b{extended_asset{{}, name{}} >= extended_asset{{}, name{"eosioaccountj"}}};


### PR DESCRIPTION
## Change Description

This change brings parity between `asset` and `extended_asset` for operators.

Closes #105.

Brief doxygen comments for some comparison operators were made more specific.



## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

These `extended_asset` operators were added:
- `extended_asset& operator*=(int64_t)`
- `extended_asset operator*(const extended_asset&, int64_t)`
- `extended_asset operator*(int64_t, const extended_asset&)`
- `int64_t operator/(const extended_asset&, const extended_asset&)`
- `extended_asset& operator/=( int64_t )`
- `extended_asset operator/( const extended_asset&, int64_t )`

This is an addition only, so no existing code should be impacted.

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->

## Test Additions

extended_asset unit tests were updated for the new operators.