### PR TITLE
Added additional build and editor files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@
 .DS_Store
 
 # Build
-build/*
+[Bb]uild*/
 cmake-build-debug/
 examples/multi_index_example/build
 examples/hello/build
@@ -49,3 +49,4 @@ __pycache__/
 *.vim
 .idea/
 .ccls-cache/
+CMakeLists.txt.user


### PR DESCRIPTION
Changed build ignore to from `build/*` to `[Bb]uild*/` to allow for example: `Build_debug/` and `build_release/` etc.
Added `CMakeLists.txt.user` to ignore QtCreator editor/debugger artifacts.