### PR TITLE
Doc Fix: Update Readme to install dep clang-tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The instructions below assume that you are building on Ubuntu 20.04.
 apt-get update && apt-get install   \
         build-essential             \
         clang                       \
+        clang-tidy                  \
         cmake                       \
         git                         \
         libxml2-dev                 \


### PR DESCRIPTION

## Change Description
One line change to README.md file. Added `clang-tidy` to list of apt dependancies to install. Found this dependency was missing and threw an error. `clang` is already in the dependency list so I figured adding `clang-tidy` would be ok. Fixes #157 

## API Changes
None

## Documentation Additions
- [x ] Documentation Additions

