### PR TITLE
compile with clang-16

### DIFF
--- a/.cicd/platforms.json
+++ b/.cicd/platforms.json
@@ -7,5 +7,8 @@
    },
    "ubuntu22": {
       "dockerfile": ".cicd/platforms/ubuntu22.Dockerfile"
+   },
+   "ubuntu22-llvm": {
+      "dockerfile": ".cicd/platforms/ubuntu22-llvm.Dockerfile"
    }
 }

--- a/.cicd/platforms/ubuntu22-llvm.Dockerfile
+++ b/.cicd/platforms/ubuntu22-llvm.Dockerfile
@@ -3,10 +3,21 @@ FROM ubuntu:jammy
 RUN apt-get update && apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
                                                       cmake \
+                                                      wget \
                                                       git \
                                                       ninja-build \
                                                       python3 \
                                                       pkg-config \
                                                       libboost-all-dev \
                                                       libcurl4-gnutls-dev \
+                                                      lsb-release \
+                                                      software-properties-common \
+                                                      gnupg \
                                                       clang-tidy
+
+RUN wget https://apt.llvm.org/llvm.sh
+RUN chmod +x llvm.sh
+RUN ./llvm.sh 16
+
+ENV CC=clang-16
+ENV CXX=clang++-16

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu18, ubuntu20, ubuntu22]
+        platform: [ubuntu18, ubuntu20, ubuntu22, ubuntu22-llvm]
     runs-on: ["self-hosted", "enf-x86-beefy"]
     container: ${{fromJSON(needs.d.outputs.p)[matrix.platform].image}}
     steps:

--- a/libraries/meta_refl/include/bluegrass/meta/function_traits.hpp
+++ b/libraries/meta_refl/include/bluegrass/meta/function_traits.hpp
@@ -65,11 +65,6 @@ namespace bluegrass { namespace meta {
       template <typename T>
       constexpr bool pass_type() { return true; }
 
-      template <typename>
-      constexpr bool is_callable_impl(...) {
-        return false;
-      }
-
       template <typename T>
       struct wrapper_t {
         using type = T;
@@ -80,12 +75,6 @@ namespace bluegrass { namespace meta {
       template <typename T, typename U>
       inline constexpr U&& make_dependent(U&& u) { return static_cast<U&&>(u); }
    }
-
-   template <auto FN>
-   inline constexpr static bool is_callable_v = BLUEGRASS_HAS_MEMBER(AUTO_PARAM_WORKAROUND(FN), operator());
-
-   template <typename F>
-   constexpr bool is_callable(F&& fn) { return BLUEGRASS_HAS_MEMBER(fn, operator()); }
 
    namespace detail {
       template <bool Decay, typename R, typename... Args>
@@ -111,7 +100,7 @@ namespace bluegrass { namespace meta {
                                                                std::tuple<std::conditional_t<Decay, std::decay_t<Args>, Args>...>>;
       template <bool Decay, typename F>
       constexpr auto get_types(F&& fn) {
-         if constexpr (is_callable_v<decltype(fn)>)
+         if constexpr (std::is_invocable<F>::value)
             return get_types<Decay>(&F::operator());
          else
             return get_types<Decay>(fn);
@@ -153,7 +142,7 @@ namespace bluegrass { namespace meta {
       constexpr auto parameters_from_impl(R(Cls::*)(Args...)const &&) ->  pack_from_t<N, Args...>;
       template <std::size_t N, typename F>
       constexpr auto parameters_from_impl(F&& fn) {
-         if constexpr (is_callable_v<decltype(fn)>)
+         if constexpr (std::is_invocable<F>::value)
             return parameters_from_impl<N>(&F::operator());
          else
             return parameters_from_impl<N>(fn);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Relates to #192
Allows to compile CDT with clang-16.
I have added new Docker image with ubuntu22 & clang-16.
This is also related to #185 

Changes:
1. `get_types` seems to be unused
2. `parameters_from_impl` is used (indirectly) by `return_type_t`  - tests for it are in `traits_tests.cpp`.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
