### PR TITLE
[Meta-Refl] Update catch2 to v2.13.10

### DIFF
--- a/libraries/meta_refl/modules/catch2_install.cmake.in
+++ b/libraries/meta_refl/modules/catch2_install.cmake.in
@@ -16,7 +16,7 @@ if (NOT ${found_project})
    ExternalProject_Add(
       catch2_external_proj 
       GIT_REPOSITORY "https://github.com/catchorg/Catch2" 
-      GIT_TAG "v2.12.2"
+      GIT_TAG "v2.13.10"
       SOURCE_DIR @CATCH2_DIRECTORY@/catch2
       BINARY_DIR @CATCH2_DIRECTORY@/catch2
       BUILD_ALWAYS 0


### PR DESCRIPTION
## Change Description
The version of catch2 in use is [old enough to fail compiles](https://github.com/catchorg/Catch2/issues/2421) on updated Linux operating systems. Update to latest version in v2.0 series to fix builds.

Ideally, it would be updated to the v3.0 series... but this fixes the build without code changes =)

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## API Changes
- No API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- No Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
