### PR TITLE
Fix ABI generator to correctly handle tables from other contracts

### DIFF
--- a/tests/toolchain/abigen-pass/singleton_other_contract.abi
+++ b/tests/toolchain/abigen-pass/singleton_other_contract.abi
@@ -1,0 +1,23 @@
+{
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT ",
+    "version": "eosio::abi/1.2",
+    "types": [],
+    "structs": [
+        {
+            "name": "whatever",
+            "base": "",
+            "fields": []
+        }
+    ],
+    "actions": [
+        {
+            "name": "whatever",
+            "type": "whatever",
+            "ricardian_contract": ""
+        }
+    ],
+    "tables": [],
+    "ricardian_clauses": [],
+    "variants": [],
+    "action_results": []
+}

--- a/tests/toolchain/abigen-pass/singleton_other_contract.cpp
+++ b/tests/toolchain/abigen-pass/singleton_other_contract.cpp
@@ -1,0 +1,30 @@
+#include <eosio/eosio.hpp>
+#include <eosio/singleton.hpp>
+
+using namespace eosio;
+
+struct [[eosio::table]] data1 {
+
+   name           someval;
+
+} data1_row;
+
+using data1table = eosio::singleton<"data1"_n, data1>;
+
+class [[eosio::contract("singleton_other_contract")]] singleton_other_contract : public contract {
+   public:
+      using contract::contract;
+      
+      struct [[eosio::table, eosio::contract("othercontract")]] data2 {
+
+         name           someval;
+
+      } data2_row;
+
+      using data2table = eosio::singleton<"data2"_n, data2>;
+
+      [[eosio::action]]
+         void whatever() {};
+
+
+};

--- a/tests/toolchain/abigen-pass/singleton_other_contract.json
+++ b/tests/toolchain/abigen-pass/singleton_other_contract.json
@@ -1,0 +1,10 @@
+{
+    "tests" : [
+       {
+          "expected" : {
+             "abi-file" : "singleton_other_contract.abi"
+          }
+       }
+    ]
+ }
+ 

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -243,8 +243,8 @@ namespace eosio { namespace cdt {
          ctables.insert(t);
       }
 
-      void add_table( uint64_t name, const clang::CXXRecordDecl* decl, bool force=false ) {
-         if (force || decl->isEosioTable() && abigen::is_eosio_contract(decl, get_contract_name())) {
+      void add_table( uint64_t name, const clang::CXXRecordDecl* decl, bool is_singleton=false ) {
+         if ((is_singleton && !decl->isEosioTable()) || (decl->isEosioTable() && abigen::is_eosio_contract(decl, get_contract_name()))) {
             abi_table t;
             t.type = decl->getNameAsString();
             t.name = name_to_string(name);


### PR DESCRIPTION
Fixes #198 

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
There was a problem in the ABI generator that added included singleton table structs from other contracts (included using header import or with eosio::contract tag) to the ABI, which was not intended. This PR fixes this problem, and the appropriate test case with the desired ABI has also been added.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
