### PR TITLE
Make leap-dev download target configurable.

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,0 +1,6 @@
+{
+    "leap-dev":{
+       "target":"main",
+       "prerelease":false
+    }
+ }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,7 +113,6 @@ jobs:
             prereleases: ${{fromJSON(needs.versions.outputs.leap-dev-prerelease)}}
             artifact-name: leap-dev-ubuntu20-amd64
             container-package: experimental-binaries
-            token: ${{github.token}}
         - name: Install leap-dev.deb (Ubuntu 20 only)
           if: matrix.platform == 'ubuntu20'
           run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,17 @@ on:
       - "release/*"
   pull_request:
   workflow_dispatch:
+    inputs:
+      override-leap-dev:
+        description: Override leap-dev target
+        type: string
+      override-leap-dev-prerelease:
+        type: choice
+        description: Override leap-dev prelease
+        options:
+        - default
+        - true
+        - false
 
 permissions:
   packages: write
@@ -53,9 +64,33 @@ jobs:
           push: true
           tags: ${{fromJSON(needs.d.outputs.p)[matrix.platform].image}}
           file: ${{fromJSON(needs.d.outputs.p)[matrix.platform].dockerfile}}
+
+  versions:
+    name: Determine Versions
+    runs-on: ubuntu-latest
+    outputs:
+      leap-dev-target: ${{steps.versions.outputs.leap-dev-target}}
+      leap-dev-prerelease: ${{steps.versions.outputs.leap-dev-prerelease}}
+    steps:
+      - name: Setup versions from input or defaults
+        id: versions
+        env:
+          GH_TOKEN: ${{github.token}}
+        run: |
+          DEFAULTS_JSON=$(curl -sSfL $(gh api https://api.github.com/repos/${{github.repository}}/contents/.cicd/defaults.json?ref=${{github.sha}} --jq .download_url))
+          echo leap-dev-target=$(echo "$DEFAULTS_JSON" | jq -r '."leap-dev".target') >> $GITHUB_OUTPUT
+          echo leap-dev-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '."leap-dev".prerelease') >> $GITHUB_OUTPUT
+
+          if [[ "${{inputs.override-leap-dev}}" != "" ]]; then
+            echo leap-dev-target=${{inputs.override-leap-dev}} >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{inputs.override-leap-dev-prerelease}}" == +(true|false) ]]; then
+            echo leap-dev-prerelease=${{inputs.override-leap-dev-prerelease}} >> $GITHUB_OUTPUT
+          fi
+
   Build:
     name: Build & Test
-    needs: [d, build-platforms]
+    needs: [d, build-platforms, versions]
     if: always() && needs.d.result == 'success' && (needs.build-platforms.result == 'success' || needs.build-platforms.result == 'skipped')
     strategy:
       fail-fast: false
@@ -69,12 +104,13 @@ jobs:
             submodules: recursive
         - name: Download leap-dev.deb (Ubuntu 20 only)
           if: matrix.platform == 'ubuntu20'
-          uses: AntelopeIO/asset-artifact-download-action@v2
+          uses: AntelopeIO/asset-artifact-download-action@v3
           with:
             owner: AntelopeIO
             repo: leap
             file: 'leap-dev.*(x86_64|amd64).deb'
-            target: main
+            target: '${{needs.versions.outputs.leap-dev-target}}'
+            prereleases: ${{fromJSON(needs.versions.outputs.leap-dev-prerelease)}}
             artifact-name: leap-dev-ubuntu20-amd64
             container-package: experimental-binaries
             token: ${{github.token}}


### PR DESCRIPTION
## Change Description
Make leap-dev download target configurable.
    
Use `defaults.json` to specify default location/target to attempt to download the `leap-dev` package from. Allow dynamic configuration through `workflow_dispatch` input in github.

Resolves: https://github.com/AntelopeIO/cdt/issues/216


For example:

The run here: [Manual Build & Test Run](https://github.com/AntelopeIO/cdt/actions/runs/6090349556) was manually dispatched from `cdt` branch `cicd-override-leap-dev-target` with the `Override leap-dev target` input set to `hotstuff_integration`.  This can be seen in the `Build & Test (ubuntu20)` output in the step `Download leap-dev.deb (Ubuntu20 only)`:
```
Run AntelopeIO/asset-artifact-download-action@v3
  with:
    owner: AntelopeIO
    repo: leap
    file: leap-dev.*(x86_64|amd64).deb
    target: hotstuff_integration
    prereleases: false
    artifact-name: leap-dev-ubuntu20-amd64
    container-package: experimental-binaries
    token: ***
    fail-on-missing-target: true
```