### PR TITLE
[4.0] fix `-fnative` linking on macOS

### DIFF
--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -6,6 +6,7 @@
 #include <string>
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+#include "llvm/ADT/ScopeExit.h"
 
 #ifdef ONLY_LD
 #define LD_CAT EosioLdToolCategory
@@ -546,6 +547,23 @@ static void GetLdDefaults(std::vector<std::string>& ldopts) {
    } else {
 #ifdef __APPLE__
       ldopts.insert(ldopts.end(), {"-arch", "x86_64", "-macosx_version_min", "10.13", "-framework", "Foundation", "-framework", "System"});
+
+      llvm::SmallString<256> Output;
+      if(llvm::sys::fs::createTemporaryFile("cdtsdkroot", ".path", Output))
+         throw std::runtime_error("Failed to create tmp file");
+      auto DeleteOutput = llvm::make_scope_exit([&](){ llvm::sys::fs::remove(Output); });
+
+      if(!eosio::cdt::environment::exec_subprogram("xcrun", {"--show-sdk-path"}, true, llvm::None, {Output.str()}))
+         throw std::runtime_error("Failed to run xcrun --show-sdk-path");
+
+      auto Buf = llvm::MemoryBuffer::getFile(Output);
+      if(!Buf)
+         throw std::runtime_error("Failed to open tmp file");
+
+      std::string sdkpath = Buf.get()->getBuffer();
+      //remove newline
+      sdkpath.resize(sdkpath.size()-1);
+      ldopts.insert(ldopts.end(), {"-syslibroot", sdkpath});
 #endif
       if (fshared_opt) {
          ldopts.emplace_back("-shared");
@@ -553,7 +571,7 @@ static void GetLdDefaults(std::vector<std::string>& ldopts) {
       else {
          ldopts.emplace_back("-static");
       }
-      ldopts.insert(ldopts.end(), {"-Bstatic", "-lnative_c++", "-lnative_c", "-lnative_eosio", "-lnative", "-lnative_rt"});
+      ldopts.insert(ldopts.end(), {"-lnative_c++", "-lnative_c", "-lnative_eosio", "-lnative", "-lnative_rt"});
    }
 }
 #endif

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -548,19 +548,19 @@ static void GetLdDefaults(std::vector<std::string>& ldopts) {
 #ifdef __APPLE__
       ldopts.insert(ldopts.end(), {"-arch", "x86_64", "-macosx_version_min", "10.13", "-framework", "Foundation", "-framework", "System"});
 
-      llvm::SmallString<256> Output;
-      if(llvm::sys::fs::createTemporaryFile("cdtsdkroot", ".path", Output))
+      llvm::SmallString<256> output;
+      if(llvm::sys::fs::createTemporaryFile("cdtsdkroot", ".path", output))
          throw std::runtime_error("Failed to create tmp file");
-      auto DeleteOutput = llvm::make_scope_exit([&](){ llvm::sys::fs::remove(Output); });
+      auto delete_output = llvm::make_scope_exit([&](){ llvm::sys::fs::remove(output); });
 
-      if(!eosio::cdt::environment::exec_subprogram("xcrun", {"--show-sdk-path"}, true, llvm::None, {Output.str()}))
+      if(!eosio::cdt::environment::exec_subprogram("xcrun", {"--show-sdk-path"}, true, llvm::None, {output.str()}))
          throw std::runtime_error("Failed to run xcrun --show-sdk-path");
 
-      auto Buf = llvm::MemoryBuffer::getFile(Output);
-      if(!Buf)
+      auto buf = llvm::MemoryBuffer::getFile(output);
+      if(!buf)
          throw std::runtime_error("Failed to open tmp file");
 
-      std::string sdkpath = Buf.get()->getBuffer();
+      std::string sdkpath = buf.get()->getBuffer();
       //remove newline
       sdkpath.resize(sdkpath.size()-1);
       ldopts.insert(ldopts.end(), {"-syslibroot", sdkpath});

--- a/tools/include/eosio/utils.hpp
+++ b/tools/include/eosio/utils.hpp
@@ -133,7 +133,8 @@ struct environment {
      return env_table;
    }
    static bool exec_subprogram(const std::string prog, std::vector<std::string> options, bool root=false,
-                               llvm::Optional<std::string> stdin_file = llvm::None) {
+                               llvm::Optional<std::string> stdin_file = llvm::None,
+                               llvm::Optional<std::string> stdout_file = llvm::None) {
       std::vector<llvm::StringRef> args;
       args.push_back(prog);
       args.insert(args.end(), options.begin(), options.end());
@@ -142,9 +143,12 @@ struct environment {
          find_path = "/usr/bin";
       if ( const auto& path = llvm::sys::findProgramByName(prog.c_str(), {find_path}) ) {
          std::vector<llvm::Optional<llvm::StringRef>> redirects;
-         if(stdin_file) {
-            redirects = { llvm::StringRef{*stdin_file}, llvm::None, llvm::None };
-         }
+         if(stdin_file || stdout_file)
+            redirects = { llvm::None, llvm::None, llvm::None };
+         if(stdin_file)
+            redirects[0] = llvm::StringRef{*stdin_file};
+         if(stdout_file)
+            redirects[1] = llvm::StringRef{*stdout_file};
          return llvm::sys::ExecuteAndWait(*path, args, {}, redirects, 0, 0, nullptr, nullptr) == 0;
       }
       else


### PR DESCRIPTION
When building cdt on macOS, it would error out about not being able to find the Foundation framework. This was because when cdt's ld driver was run with `-fnative` it didn't tell `ld` the system's SDK path.

The current SDK can be discovered via `xcrun --show-sdk-path`. I'm not sure any other way, so call off to that when creating the command line arguments to pass to `ld`. You can find something a little similar when cmake initializes its environment, so I'm not completely out of whack: https://github.com/Kitware/CMake/blob/123cdf981661c8ae32335d4ae7e1ddcbcffd09cc/Modules/Platform/Darwin-Initialize.cmake#L144

I also removed `-Bstatic` as that isn't accepted by macOS's linker any longer. afaict that is unneeded since `-static` will be passed anyways.