### PR TITLE
Revert Alias of Multi-Index Operations

### DIFF
--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -866,11 +866,11 @@ class multi_index
 
          auto secondary_keys = make_extractor_tuple::get_extractor_tuple(indices_type{}, obj);
 
-         uint64_t pk = to_raw_key(obj.primary_key());
+         uint64_t pk = _multi_index_detail::to_raw_key(obj.primary_key());
 
          updater( obj );
 
-         eosio::check( pk == to_raw_key(obj.primary_key()), "updater cannot change primary key when modifying an object" );
+         eosio::check( pk == _multi_index_detail::to_raw_key(obj.primary_key()), "updater cannot change primary key when modifying an object" );
  
          size_t size = pack_size( obj );
          //using malloc/free here potentially is not exception-safe, although WASM doesn't support exceptions

--- a/tests/unit/test_contracts/multi_index_tests.cpp
+++ b/tests/unit/test_contracts/multi_index_tests.cpp
@@ -204,41 +204,6 @@ namespace _test_multi_index
             auto itr2 = table.find(ssn);
             eosio::check(itr2 == table.end(), "idx64_general - table.erase()");
         }
-
-        // insert, update and delete by iterator
-        {
-            const uint64_t ssn = 421;
-            auto new_person = table.insert(payer, [&](auto &r)
-                                            {
-            r.id = ssn;
-            r.sec = "bob"_n.value; });
-
-            table.update(new_person, payer, [&](auto &r)
-                         { r.sec = "billy"_n.value; });
-
-            auto itr1 = table.find(ssn);
-            eosio::check(itr1 != table.end() && itr1->sec == "billy"_n.value, "idx64_general - table.update()");
-
-            table.remove(itr1);
-            auto itr2 = table.find(ssn);
-            eosio::check(itr2 == table.end(), "idx64_general - table.remove()");
-        }
-
-        // insert, update and delete by object
-        {
-            const uint64_t ssn = 421;
-            auto new_person = table.insert(payer, [&](auto &r)
-                                            {
-            r.id = ssn;
-            r.sec = "bob"_n.value; });
-
-            table.update(new_person, payer, [&](auto &r)
-                         { r.sec = "billy"_n.value; });
-
-            table.remove(new_person);
-            auto itr2 = table.find(ssn);
-            eosio::check(itr2 == table.end(), "idx64_general - table.remove()");
-        }
     }
 
     template <uint64_t TableName>

--- a/tests/unit/test_contracts/multi_index_tests.cpp
+++ b/tests/unit/test_contracts/multi_index_tests.cpp
@@ -205,7 +205,7 @@ namespace _test_multi_index
             eosio::check(itr2 == table.end(), "idx64_general - table.erase()");
         }
 
-        // insert, update and remove by iterator
+        // insert, update and delete by iterator
         {
             const uint64_t ssn = 421;
             auto new_person = table.insert(payer, [&](auto &r)
@@ -224,7 +224,7 @@ namespace _test_multi_index
             eosio::check(itr2 == table.end(), "idx64_general - table.remove()");
         }
 
-        // insert, update and remove by object
+        // insert, update and delete by object
         {
             const uint64_t ssn = 421;
             auto new_person = table.insert(payer, [&](auto &r)
@@ -235,26 +235,7 @@ namespace _test_multi_index
             table.update(new_person, payer, [&](auto &r)
                          { r.sec = "billy"_n.value; });
 
-            const auto& person_object = table.get(ssn);
-            auto& mutable_person = const_cast<record&>(person_object);
-            table.remove(mutable_person);
-            auto itr2 = table.find(ssn);
-            eosio::check(itr2 == table.end(), "idx64_general - table.remove()");
-        }
-
-        // insert, update and remove by const object
-        {
-            const uint64_t ssn = 421;
-            auto new_person = table.insert(payer, [&](auto &r)
-                                            {
-            r.id = ssn;
-            r.sec = "bob"_n.value; });
-
-            table.update(new_person, payer, [&](auto &r)
-                         { r.sec = "billy"_n.value; });
-
-            const auto& person_object = table.get(ssn);
-            table.remove(person_object);
+            table.remove(new_person);
             auto itr2 = table.find(ssn);
             eosio::check(itr2 == table.end(), "idx64_general - table.remove()");
         }


### PR DESCRIPTION
Revert the following commits from main branch due to lack of testing, and not in any release. See issue #260 for issue and PR history. 

This update is the produce of the following command. 
`git revert 65f928f a1aae5f 2b0fd5c 94ca050`

Validated by comparing against pre-merge commit.
`git diff e77c18e74 libraries/eosiolib/contracts/eosio/multi_index.hpp`
`git diff e77c18e74 tests/unit/test_contracts/`

Running Build and Test on Branch Now
