### PR TITLE
export wasm memory

### DIFF
--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -508,6 +508,7 @@ static void GetLdDefaults(std::vector<std::string>& ldopts) {
          else
             ldopts.insert(ldopts.end(), { "-e", "apply" });
          ldopts.insert(ldopts.end(), { "--only-export", "apply:function" });
+         ldopts.insert(ldopts.end(), { "--only-export", "*:memory" });
       }
       ldopts.emplace_back("-lc++");
       ldopts.emplace_back("-lc");


### PR DESCRIPTION
Exports the wasm memory.

Before,
```
wasm-objdump -j export -x eosio.token.wasm

eosio.token.wasm:	file format wasm 0x1

Section Details:

Export[1]:
 - func[56] <apply> -> "apply"
```

After,
```
wasm-objdump -j export -x eosio.token.wasm

eosio.token.wasm:	file format wasm 0x1

Section Details:

Export[2]:
 - memory[0] -> "memory"
 - func[24] <apply> -> "apply"
```

Resolves #130 