### PR TITLE
Use spring instead of leap for integration tests

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
-    "leap-dev":{
-       "target":"hotstuff_integration",
+    "spring-dev":{
+       "target":"main",
        "prerelease":false
     }
  }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,12 +8,12 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      override-leap-dev:
-        description: Override leap-dev target
+      override-spring-dev:
+        description: Override spring-dev target
         type: string
-      override-leap-dev-prerelease:
+      override-spring-dev-prerelease:
         type: choice
-        description: Override leap-dev prelease
+        description: Override spring-dev prelease
         options:
         - default
         - true
@@ -69,8 +69,8 @@ jobs:
     name: Determine Versions
     runs-on: ubuntu-latest
     outputs:
-      leap-dev-target: ${{steps.versions.outputs.leap-dev-target}}
-      leap-dev-prerelease: ${{steps.versions.outputs.leap-dev-prerelease}}
+      spring-dev-target: ${{steps.versions.outputs.spring-dev-target}}
+      spring-dev-prerelease: ${{steps.versions.outputs.spring-dev-prerelease}}
     steps:
       - name: Setup versions from input or defaults
         id: versions
@@ -78,14 +78,14 @@ jobs:
           GH_TOKEN: ${{github.token}}
         run: |
           DEFAULTS_JSON=$(curl -sSfL $(gh api https://api.github.com/repos/${{github.repository}}/contents/.cicd/defaults.json?ref=${{github.sha}} --jq .download_url))
-          echo leap-dev-target=$(echo "$DEFAULTS_JSON" | jq -r '."leap-dev".target') >> $GITHUB_OUTPUT
-          echo leap-dev-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '."leap-dev".prerelease') >> $GITHUB_OUTPUT
+          echo spring-dev-target=$(echo "$DEFAULTS_JSON" | jq -r '."spring-dev".target') >> $GITHUB_OUTPUT
+          echo spring-dev-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '."spring-dev".prerelease') >> $GITHUB_OUTPUT
 
-          if [[ "${{inputs.override-leap-dev}}" != "" ]]; then
-            echo leap-dev-target=${{inputs.override-leap-dev}} >> $GITHUB_OUTPUT
+          if [[ "${{inputs.override-spring-dev}}" != "" ]]; then
+            echo spring-dev-target=${{inputs.override-spring-dev}} >> $GITHUB_OUTPUT
           fi
-          if [[ "${{inputs.override-leap-dev-prerelease}}" == +(true|false) ]]; then
-            echo leap-dev-prerelease=${{inputs.override-leap-dev-prerelease}} >> $GITHUB_OUTPUT
+          if [[ "${{inputs.override-spring-dev-prerelease}}" == +(true|false) ]]; then
+            echo spring-dev-prerelease=${{inputs.override-spring-dev-prerelease}} >> $GITHUB_OUTPUT
           fi
 
   Build:
@@ -102,22 +102,22 @@ jobs:
         - uses: actions/checkout@v3
           with:
             submodules: recursive
-        - name: Download leap-dev.deb (Ubuntu 22 only)
+        - name: Download spring-dev.deb (Ubuntu 22 only)
           if: matrix.platform == 'ubuntu22'
           uses: AntelopeIO/asset-artifact-download-action@v3
           with:
             owner: AntelopeIO
-            repo: leap
-            file: 'leap-dev.*ubuntu22\.04_amd64.deb'
-            target: '${{needs.versions.outputs.leap-dev-target}}'
-            prereleases: ${{fromJSON(needs.versions.outputs.leap-dev-prerelease)}}
-            artifact-name: leap-dev-ubuntu22-amd64
+            repo: spring
+            file: 'spring-dev.*ubuntu22\.04_amd64.deb'
+            target: '${{needs.versions.outputs.spring-dev-target}}'
+            prereleases: ${{fromJSON(needs.versions.outputs.spring-dev-prerelease)}}
+            artifact-name: spring-dev-ubuntu22-amd64
             container-package: experimental-binaries
-        - name: Install leap-dev.deb (Ubuntu 22 only)
+        - name: Install spring-dev.deb (Ubuntu 22 only)
           if: matrix.platform == 'ubuntu22'
           run: |
             apt-get update && apt-get upgrade -y
-            apt install -y ./leap-dev*.deb
+            apt install -y ./spring-dev*.deb
             rm ./leap-dev*.deb
         - name: Build & Test
           run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,7 +118,7 @@ jobs:
           run: |
             apt-get update && apt-get upgrade -y
             apt install -y ./spring-dev*.deb
-            rm ./leap-dev*.deb
+            rm ./spring-dev*.deb
         - name: Build & Test
           run: |
             mkdir build

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Then, execute the following command in the same terminal session that you will u
 export spring_DIR=/path/to/spring/build/lib/cmake/spring
 ```
 
-Now you can continue with the steps to build CDT as described. When you run `cmake` make sure that it does not report `spring package not found`. If it does, this means CDT was not able to find a build of Leap at the specified path in `spring_DIR` and will therefore continue without building the integration tests.
+Now you can continue with the steps to build CDT as described. When you run `cmake` make sure that it does not report `spring package not found`. If it does, this means CDT was not able to find a build of Spring at the specified path in `spring_DIR` and will therefore continue without building the integration tests.
 
 ### ccache
 

--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ python3 -m pip install pygments
 
 ### Allowing integration tests to build
 
-Integration tests require access to a build of [Leap](https://github.com/AntelopeIO/leap), a C++ implementation of the Antelope protocol. Simply installing Leap from a binary package will not be sufficient.
+Integration tests require access to a build of [Spring](https://github.com/AntelopeIO/spring), a C++ implementation of the Antelope protocol. Simply installing Spring from a binary package will not be sufficient.
 
-If you do not wish to build Leap, you can continue with building CDT but without building the integration tests. Otherwise, follow the instructions below before running `cmake`.
+If you do not wish to build Spring, you can continue with building CDT but without building the integration tests. Otherwise, follow the instructions below before running `cmake`.
 
-First, ensure that Leap has been built from source (see Leap's [README](https://github.com/AntelopeIO/leap#building-from-source) for details) and identify the build path, e.g. `/path/to/leap/build/`.
+First, ensure that Spring has been built from source (see Spring's [README](https://github.com/AntelopeIO/spring#building-from-source) for details) and identify the build path, e.g. `/path/to/spring/build/`.
 
 Then, execute the following command in the same terminal session that you will use to build CDT:
 
 ```sh
-export leap_DIR=/path/to/leap/build/lib/cmake/leap
+export spring_DIR=/path/to/spring/build/lib/cmake/spring
 ```
 
-Now you can continue with the steps to build CDT as described. When you run `cmake` make sure that it does not report `leap package not found`. If it does, this means CDT was not able to find a build of Leap at the specified path in `leap_DIR` and will therefore continue without building the integration tests.
+Now you can continue with the steps to build CDT as described. When you run `cmake` make sure that it does not report `spring package not found`. If it does, this means CDT was not able to find a build of Leap at the specified path in `spring_DIR` and will therefore continue without building the integration tests.
 
 ### ccache
 

--- a/docs/07_best-practices/08_abi/00_understanding-abi-files.md
+++ b/docs/07_best-practices/08_abi/00_understanding-abi-files.md
@@ -35,7 +35,7 @@ Start with an empty ABI, for exemplification we will work based on the `eosio.to
 An ABI enables any client or interface to interpret and even generate a GUI for your contract. For this to work consistently, describe the custom types that are used as a parameter in any public action or struct that needs to be described in the ABI.
 
 [[info | Built-in Types]]
-| Antelope implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with Antelope's built-ins, they are defined [here](https://github.com/AntelopeIO/leap/blob/6817911900a088c60f91563995cf482d6b380b2d/libraries/chain/abi_serializer.cpp#L88-L129)
+| Antelope implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with Antelope's built-ins, they are defined [here](https://github.com/AntelopeIO/spring/blob/5a3550a6fec4c1865e8aca07aa97693f720afe72/libraries/chain/abi_serializer.cpp#L92-L130)
 
 
 ```json

--- a/docs/09_tutorials/03_create-an-abi-file.md
+++ b/docs/09_tutorials/03_create-an-abi-file.md
@@ -35,7 +35,7 @@ An ABI enables any client or interface to interpret and even generate an GUI for
 [[info]]
 |Built-in Types
 
-Antelope implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with Antelope's built-ins, they are defined [here](https://github.com/AntelopeIO/leap/blob/6817911900a088c60f91563995cf482d6b380b2d/libraries/chain/abi_serializer.cpp#L88-L129).
+Antelope implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with Antelope's built-ins, they are defined [here](https://github.com/AntelopeIO/spring/blob/5a3550a6fec4c1865e8aca07aa97693f720afe72/libraries/chain/abi_serializer.cpp#L92-L130).
 
 Using **eosio.token** as an example, the only type that requires a description in the ABI file is `account_name`. The ABI uses "new_type_name" to describe explicit types, in this case `account_name`, and `account_name` is an alias of `name` type.
 

--- a/modules/TestsExternalProject.txt
+++ b/modules/TestsExternalProject.txt
@@ -16,9 +16,9 @@ ExternalProject_Add(
 )
 
 
-find_package(leap QUIET)
+find_package(spring QUIET)
 
-if (leap_FOUND)
+if (spring_FOUND)
    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
       set(TEST_BUILD_TYPE "Debug")
    else()
@@ -40,5 +40,5 @@ if (leap_FOUND)
      BUILD_ALWAYS 1
    )
 else()
-   message(STATUS "leap package not found, skipping building integration tests")
+   message(STATUS "spring package not found, skipping building integration tests")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/unit/version_tests.sh ${CMAKE_BINARY_
 add_test(NAME version_tests COMMAND ${CMAKE_BINARY_DIR}/tests/unit/version_tests.sh "${VERSION_FULL}" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST version_tests PROPERTY LABELS unit_tests)
 
-if (leap_FOUND)
+if (spring_FOUND)
    add_test(integration_tests ${CMAKE_BINARY_DIR}/tests/integration/integration_tests)
    set_property(TEST integration_tests PROPERTY LABELS integration_tests)
 endif()

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required( VERSION 3.5 )
 
-set(EOSIO_VERSION_MIN "3.1")
+set(EOSIO_VERSION_MIN "1.0")
 set(EOSIO_VERSION_SOFT_MAX "5.0")
 #set(EOSIO_VERSION_HARD_MAX "")
 
-find_package(leap)
+find_package(spring)
 
 find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 find_library(GMP_LIBRARY gmp)
@@ -17,11 +17,11 @@ EOSIO_CHECK_VERSION(VERSION_OUTPUT "${EOSIO_VERSION}"
                                    "${EOSIO_VERSION_HARD_MAX}"
                                    VERSION_MATCH_ERROR_MSG)
 if(VERSION_OUTPUT STREQUAL "MATCH")
-   message(STATUS "Using Leap version ${EOSIO_VERSION}")
+   message(STATUS "Using Spring version ${EOSIO_VERSION}")
 elseif(VERSION_OUTPUT STREQUAL "WARN")
-   message(WARNING "Using Leap version ${EOSIO_VERSION} even though it exceeds the maximum supported version of ${EOSIO_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use Leap version ${EOSIO_VERSION_SOFT_MAX}.x")
+   message(WARNING "Using Spring version ${EOSIO_VERSION} even though it exceeds the maximum supported version of ${EOSIO_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use Spring version ${EOSIO_VERSION_SOFT_MAX}.x")
 else() # INVALID OR MISMATCH
-   message(FATAL_ERROR "Found Leap version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Leap version ${EOSIO_VERSION_SOFT_MAX}.x")
+   message(FATAL_ERROR "Found Spring version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Spring version ${EOSIO_VERSION_SOFT_MAX}.x")
 endif(VERSION_OUTPUT STREQUAL "MATCH")
 
 

--- a/tests/integration/multi_index_tests.cpp
+++ b/tests/integration/multi_index_tests.cpp
@@ -18,7 +18,7 @@ using namespace eosio::testing;
 
 BOOST_AUTO_TEST_SUITE(multi_index_tests)
 
-// this test is copy from spring test_api_multi_index
+// this test is copied from Spring test_api_multi_index
 BOOST_FIXTURE_TEST_CASE(main_multi_index_tests, TESTER) { try {
    produce_blocks(1);
    create_account( "testapi"_n );

--- a/tests/integration/multi_index_tests.cpp
+++ b/tests/integration/multi_index_tests.cpp
@@ -18,7 +18,7 @@ using namespace eosio::testing;
 
 BOOST_AUTO_TEST_SUITE(multi_index_tests)
 
-// this test is copy from leap test_api_multi_index
+// this test is copy from spring test_api_multi_index
 BOOST_FIXTURE_TEST_CASE(main_multi_index_tests, TESTER) { try {
    produce_blocks(1);
    create_account( "testapi"_n );


### PR DESCRIPTION
## Change Description

- Update integration tests to use Spring instead of Leap

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

Resolves #276 