### PR TITLE
[4.1] pick from main: Update c interface of set_finalizers

### DIFF
--- a/libraries/eosiolib/capi/eosio/instant_finality.h
+++ b/libraries/eosiolib/capi/eosio/instant_finality.h
@@ -12,14 +12,15 @@ extern "C" {
 
 /**
  * Submits a finalizer policy change to Instant Finality
- * 
+ *
+ * @param packed_finalizer_format - format of the finalizer_policy object, currently only supports 0
  * @param data - pointer finalizer_policy object packed as bytes
  * @param len  - size of packed finalazer_policy object
  * @pre `data` is a valid pointer to a range of memory at least `len` bytes long that contains packed abi_finalizer_policy data
  * abi_finalizer_policy structure is defined in instant_finality.hpp
  */
 __attribute__((eosio_wasm_import))
-void set_finalizers( const char* data, uint32_t len );
+void set_finalizers( uint64_t packed_finalizer_format, const char* data, uint32_t len );
 
 #ifdef __cplusplus
 }

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -906,8 +906,8 @@ extern "C" {
       return intrinsics::get().call<intrinsics::get_active_security_group>(data, datalen);
    }
   
-   void set_finalizers(const char* data, uint32_t len) {
-      intrinsics::get().call<intrinsics::set_finalizers>(data, len);
+   void set_finalizers(uint64_t packed_finalizer_format, const char* data, uint32_t len) {
+      intrinsics::get().call<intrinsics::set_finalizers>(packed_finalizer_format, data, len);
    }
   
 } // extern "C"

--- a/tests/unit/test_contracts/capi/privileged.c
+++ b/tests/unit/test_contracts/capi/privileged.c
@@ -12,5 +12,5 @@ void test_privileged( void ) {
    set_blockchain_parameters_packed(NULL, 0);
    get_blockchain_parameters_packed(NULL, 0);
    preactivate_feature(NULL);
-   set_finalizers(NULL, 0);
+   set_finalizers(0, NULL, 0);
 }


### PR DESCRIPTION
4.1 branched before #280 but this change is needed to get tests to actually pass. Add #280 change in to 4.1