### PR TITLE
[4.1] upload ubuntu20 .deb package

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,13 +127,13 @@ jobs:
             make -j $(nproc)
             cd tests
             ctest -j $(nproc) --output-on-failure
-        - name: Package (Ubuntu 22 only)
-          if: matrix.platform == 'ubuntu22'
+        - name: Package (Ubuntu 20 only)
+          if: matrix.platform == 'ubuntu20'
           run: |
             cd build/packages
             bash generate_package.sh deb ubuntu amd64
-        - name: Upload (Ubuntu 22 only)
-          if: matrix.platform == 'ubuntu22'
+        - name: Upload (Ubuntu 20 only)
+          if: matrix.platform == 'ubuntu20'
           uses: actions/upload-artifact@v3
           with:
             name: cdt_ubuntu_package_amd64


### PR DESCRIPTION
The ubuntu22 package will work on 22+ but not 20. The ubuntu20 package will work on 20, 22, and 24. Unless we no longer support ubuntu20 we should be using that .deb instead.