### PR TITLE
[4.1] add ubuntu 24.04 to CI

### DIFF
--- a/.cicd/platforms.json
+++ b/.cicd/platforms.json
@@ -7,5 +7,8 @@
    },
    "ubuntu22-llvm": {
       "dockerfile": ".cicd/platforms/ubuntu22-llvm.Dockerfile"
+   },
+   "ubuntu24": {
+      "dockerfile": ".cicd/platforms/ubuntu24.Dockerfile"
    }
 }

--- a/.cicd/platforms/ubuntu24.Dockerfile
+++ b/.cicd/platforms/ubuntu24.Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:noble
+
+RUN apt-get update && apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
+                                                      cmake \
+                                                      git \
+                                                      ninja-build \
+                                                      python3 \
+                                                      pkg-config \
+                                                      libboost-all-dev \
+                                                      libcurl4-gnutls-dev \
+                                                      clang-tidy

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu20, ubuntu22, ubuntu22-llvm]
+        platform: [ubuntu20, ubuntu22, ubuntu22-llvm, ubuntu24]
     runs-on: ["self-hosted", "enf-x86-beefy"]
     container: ${{fromJSON(needs.d.outputs.p)[matrix.platform].image}}
     steps:


### PR DESCRIPTION
With Ubuntu 24.04 released and the README stating
> Recent Ubuntu LTS releases are the only Linux distributions that we fully support
https://github.com/AntelopeIO/cdt/blob/0ab129eb93addcfcc6203f0bbed6d71351c9afb3/README.md?plain=1#L31

might as well make sure it's building/working on ubuntu 24 too.