### PR TITLE
[4.1 -> main] use `antelope-spring-dev.deb` instead of `spring-dev.deb`; fix finality test

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,5 +1,5 @@
 {
-    "spring-dev":{
+    "antelope-spring-dev":{
        "target":"main",
        "prerelease":false
     }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,12 +8,12 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      override-spring-dev:
-        description: Override spring-dev target
+      override-antelope-spring-dev:
+        description: Override antelope-spring-dev target
         type: string
-      override-spring-dev-prerelease:
+      override-antelope-spring-dev-prerelease:
         type: choice
-        description: Override spring-dev prelease
+        description: Override antelope-spring-dev prelease
         options:
         - default
         - true
@@ -69,8 +69,8 @@ jobs:
     name: Determine Versions
     runs-on: ubuntu-latest
     outputs:
-      spring-dev-target: ${{steps.versions.outputs.spring-dev-target}}
-      spring-dev-prerelease: ${{steps.versions.outputs.spring-dev-prerelease}}
+      antelope-spring-dev-target: ${{steps.versions.outputs.antelope-spring-dev-target}}
+      antelope-spring-dev-prerelease: ${{steps.versions.outputs.antelope-spring-dev-prerelease}}
     steps:
       - name: Setup versions from input or defaults
         id: versions
@@ -78,14 +78,14 @@ jobs:
           GH_TOKEN: ${{github.token}}
         run: |
           DEFAULTS_JSON=$(curl -sSfL $(gh api https://api.github.com/repos/${{github.repository}}/contents/.cicd/defaults.json?ref=${{github.sha}} --jq .download_url))
-          echo spring-dev-target=$(echo "$DEFAULTS_JSON" | jq -r '."spring-dev".target') >> $GITHUB_OUTPUT
-          echo spring-dev-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '."spring-dev".prerelease') >> $GITHUB_OUTPUT
+          echo antelope-spring-dev-target=$(echo "$DEFAULTS_JSON" | jq -r '."antelope-spring-dev".target') >> $GITHUB_OUTPUT
+          echo antelope-spring-dev-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '."antelope-spring-dev".prerelease') >> $GITHUB_OUTPUT
 
-          if [[ "${{inputs.override-spring-dev}}" != "" ]]; then
-            echo spring-dev-target=${{inputs.override-spring-dev}} >> $GITHUB_OUTPUT
+          if [[ "${{inputs.override-antelope-spring-dev}}" != "" ]]; then
+            echo antelope-spring-dev-target=${{inputs.override-antelope-spring-dev}} >> $GITHUB_OUTPUT
           fi
-          if [[ "${{inputs.override-spring-dev-prerelease}}" == +(true|false) ]]; then
-            echo spring-dev-prerelease=${{inputs.override-spring-dev-prerelease}} >> $GITHUB_OUTPUT
+          if [[ "${{inputs.override-antelope-spring-dev-prerelease}}" == +(true|false) ]]; then
+            echo antelope-spring-dev-prerelease=${{inputs.override-antelope-spring-dev-prerelease}} >> $GITHUB_OUTPUT
           fi
 
   Build:
@@ -102,23 +102,23 @@ jobs:
         - uses: actions/checkout@v3
           with:
             submodules: recursive
-        - name: Download spring-dev.deb (Ubuntu 22 only)
+        - name: Download antelope-spring-dev.deb (Ubuntu 22 only)
           if: matrix.platform == 'ubuntu22'
           uses: AntelopeIO/asset-artifact-download-action@v3
           with:
             owner: AntelopeIO
             repo: spring
-            file: 'spring-dev.*ubuntu22\.04_amd64.deb'
-            target: '${{needs.versions.outputs.spring-dev-target}}'
-            prereleases: ${{fromJSON(needs.versions.outputs.spring-dev-prerelease)}}
-            artifact-name: spring-dev-ubuntu22-amd64
-            container-package: experimental-binaries
-        - name: Install spring-dev.deb (Ubuntu 22 only)
+            file: 'antelope-spring-dev.*ubuntu22\.04_amd64.deb'
+            target: '${{needs.versions.outputs.antelope-spring-dev-target}}'
+            prereleases: ${{fromJSON(needs.versions.outputs.antelope-spring-dev-prerelease)}}
+            artifact-name: antelope-spring-dev-ubuntu22-amd64
+            container-package: antelope-spring-experimental-binaries
+        - name: Install antelope-spring-dev.deb (Ubuntu 22 only)
           if: matrix.platform == 'ubuntu22'
           run: |
             apt-get update && apt-get upgrade -y
-            apt install -y ./spring-dev*.deb
-            rm ./spring-dev*.deb
+            apt install -y ./antelope-spring-dev*.deb
+            rm ./antelope-spring-dev*.deb
         - name: Build & Test
           run: |
             mkdir build

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ CDT currently supports Linux x86_64 Debian packages. Visit the [release page](ht
 Download the appropriate version of the Debian package and then install it. To download and install the latest version, run the following:
 
 ```sh
-wget https://github.com/AntelopeIO/cdt/releases/download/v4.1.0-rc1/cdt_4.1.0-rc1_amd64.deb
-sudo apt install ./cdt_4.1.0-rc1_amd64.deb
+wget https://github.com/AntelopeIO/cdt/releases/download/v4.0.1/cdt_4.0.1_amd64.deb
+sudo apt install ./cdt_4.0.1_amd64.deb
 ```
 ### Debian package uninstall
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ CDT currently supports Linux x86_64 Debian packages. Visit the [release page](ht
 Download the appropriate version of the Debian package and then install it. To download and install the latest version, run the following:
 
 ```sh
-wget https://github.com/AntelopeIO/cdt/releases/download/v4.0.1/cdt_4.0.1_amd64.deb
-sudo apt install ./cdt_4.0.1_amd64.deb
+wget https://github.com/AntelopeIO/cdt/releases/download/v4.1.0-rc1/cdt_4.1.0-rc1_amd64.deb
+sudo apt install ./cdt_4.1.0-rc1_amd64.deb
 ```
 ### Debian package uninstall
 
@@ -28,9 +28,9 @@ sudo apt remove cdt
 
 ## Building from source
 
-Recent Ubuntu LTS releases are the only Linux distributions that we fully support. Other Linux distros and other POSIX operating systems (such as macOS) are tended to on a best-effort basis and may not be full featured. 
+Recent Ubuntu LTS releases are the only Linux distributions that we fully support. Other Linux distros and other POSIX operating systems (such as macOS) are tended to on a best-effort basis and may not be full featured.
 
-The instructions below assume that you are building on Ubuntu 20.04. 
+The instructions below assume that you are building on Ubuntu 20.04.
 
 ### Install dependencies
 
@@ -136,7 +136,7 @@ Installing CDT globally on your system will install the following tools in a loc
 * cdt-strip
 * eosio-pp
 * eosio-wasm2wast
-* eosio-wast2wasm 
+* eosio-wast2wasm
 
 It will also install CMake files for CDT accessible within a `cmake/cdt` directory located within your system's `lib` directory.
 #### Manual installation

--- a/tests/integration/instant_finality_tests.cpp
+++ b/tests/integration/instant_finality_tests.cpp
@@ -34,12 +34,13 @@ BOOST_FIXTURE_TEST_CASE(instant_finality_test, tester) try {
     abi_serializer::to_variant( *cur_block, pretty_output, get_resolver(), fc::microseconds::maximum() );
     std::cout << fc::json::to_string(pretty_output, fc::time_point::now() + abi_serializer_max_time) << std::endl;
     BOOST_REQUIRE(pretty_output.get_object().contains("instant_finality_extension"));
-    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["generation"], 1);
-    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["threshold"], 1);
-    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"].size(), 1u);
-    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(0)]["description"], "test_desc");
-    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(0)]["weight"], 1);
-    BOOST_REQUIRE_EQUAL(pretty_output["instant_finality_extension"]["new_finalizer_policy"]["finalizers"][size_t(0)]["public_key"], "PUB_BLS_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX-JRYlFYrO_qKt_x439vUJ2DkZ32Od6AdJZ-S9dWRE9Sy-7Q6bNjpoIOP0cWzkKC1DqmhfE3paW-KThA3noLkV8SsILcfxpQ");
+
+    std::string output_json = fc::json::to_pretty_string(pretty_output);
+    BOOST_TEST(output_json.find("\"generation\": 2") != std::string::npos);
+    BOOST_TEST(output_json.find("\"threshold\": 1") != std::string::npos);
+    BOOST_TEST(output_json.find("\"description\": \"test_desc\"") != std::string::npos);
+    BOOST_TEST(output_json.find("\"weight\": 1") != std::string::npos);
+    BOOST_TEST(output_json.find("PUB_BLS_dEvut0ydHevDGP6Ef3O4Iq6QXf9jUcMUT1nCJRX-JRYlFYrO_qKt_x439vUJ2DkZ32Od6AdJZ-S9dWRE9Sy-7Q6bNjpoIOP0cWzkKC1DqmhfE3paW-KThA3noLkV8SsILcfxpQ") != std::string::npos);
 
     // testing wrong public key size
     BOOST_CHECK_THROW(push_action(config::system_account_name, "setfinalizer"_n, "test"_n, mvo()


### PR DESCRIPTION
merges to main
* #282 
* #292

But also tacks on c250347 which effectively undoes much of #282 since the link in main's README ought to remain the most recent stable release until 4.1.0 is released.

I think going forward maybe we don't touch the URL in the release branch until the final (first non-rc) release. (the headache/confusion around this is exactly why I removed direct download links from leap/spring's README :innocent: )