### PR TITLE
instant_finality_extension renamed to finality_extension

### DIFF
--- a/tests/integration/instant_finality_tests.cpp
+++ b/tests/integration/instant_finality_tests.cpp
@@ -33,9 +33,9 @@ BOOST_FIXTURE_TEST_CASE(instant_finality_test, tester) try {
     fc::variant pretty_output;
     abi_serializer::to_variant( *cur_block, pretty_output, get_resolver(), fc::microseconds::maximum() );
     std::cout << fc::json::to_string(pretty_output, fc::time_point::now() + abi_serializer_max_time) << std::endl;
-    BOOST_REQUIRE(pretty_output.get_object().contains("instant_finality_extension"));
 
     std::string output_json = fc::json::to_pretty_string(pretty_output);
+    BOOST_TEST(output_json.find("finality_extension") != std::string::npos);
     BOOST_TEST(output_json.find("\"generation\": 2") != std::string::npos);
     BOOST_TEST(output_json.find("\"threshold\": 1") != std::string::npos);
     BOOST_TEST(output_json.find("\"description\": \"test_desc\"") != std::string::npos);


### PR DESCRIPTION
## Change Description

`instant_finality_extension` renamed to `finality_extension` in https://github.com/AntelopeIO/spring/pull/364

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
