### PR TITLE
disable CFL Alias Analysis by default; resolving at least one case of indeterministic build output

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,7 +5,6 @@ include( CDTMacros )
 
 macro(add_cdt_unit_test TEST_NAME)
    add_native_executable(${TEST_NAME} ${TEST_NAME}.cpp)
-   target_compile_options(${TEST_NAME} PRIVATE -fno-cfl-aa)
    if(CMAKE_BUILD_TYPE STREQUAL "Release")
       target_compile_options(${TEST_NAME} PRIVATE -O2)
    elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -80,9 +80,9 @@ static cl::opt<bool> fno_lto_opt(
     "fno-lto",
     cl::desc("Disable LTO"),
     cl::cat(LD_CAT));
-static cl::opt<bool> fno_cfl_aa_opt(
-      "fno-cfl-aa",
-      cl::desc("Disable CFL Alias Analysis"),
+static cl::opt<bool> fcfl_aa_opt(
+      "fcfl-aa",
+      cl::desc("Enable CFL Alias Analysis"),
       cl::cat(LD_CAT));
 static cl::opt<bool> fno_stack_first_opt(
       "fno-stack-first",
@@ -617,7 +617,7 @@ static Options CreateOptions(bool add_defaults=true) {
    else
       pp_dir = eosio::cdt::whereami::where();
 
-   if (!fno_cfl_aa_opt) {
+   if (fcfl_aa_opt) {
       copts.emplace_back("-mllvm");
       copts.emplace_back("-use-cfl-aa-in-codegen=both");
       agopts.emplace_back("-mllvm");


### PR DESCRIPTION
This resolved system contract build indeterminism for me; don't know what the negative consequences are though
