### PR TITLE
[4.1] disable CFL Alias Analysis by default; fixes known cases of indeterministic build output

### DIFF
--- a/docs/03_command-reference/cdt-cc.md
+++ b/docs/03_command-reference/cdt-cc.md
@@ -47,7 +47,7 @@ compiler options:
   -finline-hint-functions  - Inline functions which are (explicitly or implicitly) marked inline
   -fmerge-all-constants    - Allow merging of constants
   -fnative                 - Compile and link for x86-64
-  -fno-cfl-aa              - Disable CFL Alias Analysis
+  -fcfl-aa                 - Enable CFL Alias Analysis
   -fno-elide-constructors  - Disable C++ copy constructor elision
   -fno-lto                 - Disable LTO
   -fno-post-pass           - Don't run post processing pass

--- a/docs/03_command-reference/cdt-cpp.md
+++ b/docs/03_command-reference/cdt-cpp.md
@@ -49,7 +49,7 @@ compiler options:
   -finline-hint-functions  - Inline functions which are (explicitly or implicitly) marked inline
   -fmerge-all-constants    - Allow merging of constants
   -fnative                 - Compile and link for x86-64
-  -fno-cfl-aa              - Disable CFL Alias Analysis
+  -cfl-aa                  - Enable CFL Alias Analysis
   -fno-elide-constructors  - Disable C++ copy constructor elision
   -fno-lto                 - Disable LTO
   -fno-post-pass           - Don't run post processing pass

--- a/docs/03_command-reference/cdt-ld.md
+++ b/docs/03_command-reference/cdt-ld.md
@@ -21,7 +21,7 @@ ld options:
   -L=<string>       - Add directory to library search path
   -fasm             - Assemble file for x86-64
   -fnative          - Compile and link for x86-64
-  -fno-cfl-aa       - Disable CFL Alias Analysis
+  -fcfl-aa          - Enable CFL Alias Analysis
   -fno-lto          - Disable LTO
   -fno-post-pass    - Don't run post processing pass
   -fno-stack-first  - Don't set the stack first in memory

--- a/docs/man/cdt-cc.1.md
+++ b/docs/man/cdt-cc.1.md
@@ -167,9 +167,9 @@ execution in Antelope block chain virtual machines.
     
     Compile and link for x86-64
     
-**`--fno-cfl-aa`**
+**`--fcfl-aa`**
     
-    Disable CFL Alias Analysis
+    Enable CFL Alias Analysis
     
 **`--fno-elide-constructors`**
     

--- a/docs/man/cdt-cpp.1.md
+++ b/docs/man/cdt-cpp.1.md
@@ -187,9 +187,9 @@ execution in Antelope block chain virtual machines.
     
     Compile and link for x86-64
     
-**`--fno-cfl-aa`**
+**`--fcfl-aa`**
     
-    Disable CFL Alias Analysis
+    Enable CFL Alias Analysis
     
 **`--fno-elide-constructors`**
     

--- a/docs/man/cdt-ld.1.md
+++ b/docs/man/cdt-ld.1.md
@@ -39,9 +39,9 @@ execution in Antelope block chain virtual machines.
 
     Compile and link for x86-64
     
-**`--fno-cfl-aa`**
+**`--fcfl-aa`**
 
-    Disable CFL Alias Analysis
+    Enable CFL Alias Analysis
     
 **`--fno-lto`**
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,7 +5,6 @@ include( CDTMacros )
 
 macro(add_cdt_unit_test TEST_NAME)
    add_native_executable(${TEST_NAME} ${TEST_NAME}.cpp)
-   target_compile_options(${TEST_NAME} PRIVATE -fno-cfl-aa)
    if(CMAKE_BUILD_TYPE STREQUAL "Release")
       target_compile_options(${TEST_NAME} PRIVATE -O2)
    elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -80,9 +80,9 @@ static cl::opt<bool> fno_lto_opt(
     "fno-lto",
     cl::desc("Disable LTO"),
     cl::cat(LD_CAT));
-static cl::opt<bool> fno_cfl_aa_opt(
-      "fno-cfl-aa",
-      cl::desc("Disable CFL Alias Analysis"),
+static cl::opt<bool> fcfl_aa_opt(
+      "fcfl-aa",
+      cl::desc("Enable CFL Alias Analysis"),
       cl::cat(LD_CAT));
 static cl::opt<bool> fno_stack_first_opt(
       "fno-stack-first",
@@ -617,7 +617,7 @@ static Options CreateOptions(bool add_defaults=true) {
    else
       pp_dir = eosio::cdt::whereami::where();
 
-   if (!fno_cfl_aa_opt) {
+   if (fcfl_aa_opt) {
       copts.emplace_back("-mllvm");
       copts.emplace_back("-use-cfl-aa-in-codegen=both");
       agopts.emplace_back("-mllvm");


### PR DESCRIPTION
We've struggled with cdt generating slightly different outputs build-to-build. Typically the number of output permutations is low which allows eventually coming to a consensus between two independent build environments (e.g. two individuals building a contract) by just building over and over until matching up, but clearly this is not ideal behavior and may not always be the case.

The CFL Alias Analysis optimization looks to be the source of the build indeterminism. Disable it by default, and switch the exposed option to allow it to be reenabled in case someone out there really needs it, or finds some severe regression due to the removal of this optimization. (I'm tempted to just remove it entirely: LLVM 9 documents this optimization pass as experimental)

Technically this is a breaking change (removal of `-fno-cfl-aa` option). An alternative is to add the new `-fcfl-aa` _and_ keep the existing `-fno-cfl-aa`. But then I have to figure out how to properly handle repeated options here (someone passing `-fcfl-aa -fno-cfl-aa -fcfl-aa`). I am not really convinced it's worth making this more complex; but we can discuss if someone has a strong opinion about it w.r.t. no breaking changes in a minor release.

Disabling this optimization makes a very marginal increase in contract size; I measured two contracts' size in bytes:
| contract  | with CFL AA | no CFL AA | Increase |
 | ------------- | ------------- | ------------- | ------------- |
| eosio.system | 371557  | 371589 | <0.01% |
| eosio.evm | 478959| 480609|  0.3% |

FWIW, eosio.evm's stack/data did not increase. I do not have any performance metrics. With such a small change in compiled size it's unlikely there is a significant performance delta, but there is still a chance.