### PR TITLE
Fix missing reset when deserializing std::optional if serialized value is empty

### DIFF
--- a/libraries/eosiolib/core/eosio/datastream.hpp
+++ b/libraries/eosiolib/core/eosio/datastream.hpp
@@ -456,7 +456,7 @@ inline datastream<Stream>& operator>>(datastream<Stream>& ds, std::optional<T>& 
      T val;
      ds >> val;
      opt = val;
-  }
+  } else { opt.reset(); }
   return ds;
 }
 

--- a/tests/unit/datastream_tests.cpp
+++ b/tests/unit/datastream_tests.cpp
@@ -351,6 +351,13 @@ EOSIO_TEST_BEGIN(datastream_stream_test)
    ds.seekp(0);
    ds >> o;
    CHECK_EQUAL( co, o )
+   // test upacking an empty std::optional to a non-empty works
+   static const optional<char> co1{};  // empty
+   ds.seekp(0);
+   ds << co1;
+   ds.seekp(0);
+   ds >> o;  // o had value
+   CHECK_EQUAL( co1, o )
 
    // ---------
    // std::pair


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Fixes the issue that the target is not reset if the source does not have a value. The issue will cause mismatch of source and target if the target already has a value, as that value will be kept.

Resolves https://github.com/AntelopeIO/cdt/issues/334.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
