### PR TITLE
SC: Implement new sync call host functions

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
     "antelope-spring-dev":{
-       "target":"main",
+       "target":"sync_call",
        "prerelease":false
     }
  }

--- a/libraries/eosiolib/capi/eosio/call.h
+++ b/libraries/eosiolib/capi/eosio/call.h
@@ -1,0 +1,68 @@
+/**
+ *  @file
+ */
+#pragma once
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup call_c Call C API
+ * @ingroup c_api
+ * @brief Defines API for querying call and making call
+ */
+
+/**
+ *  Make a (sync) call in the context of this call's parent action or parent call
+ *
+ *  @param receiver - the name of the account that the sync call is made to
+ *  @param flags - flags (bits) representing blockchain level requirements about
+ *                 the call. Currently LSB bit indicates read-only. All other bits
+ *                 are reserved to be 0
+ *  @param data - the data of the sync call, which may include function name, arguments, and other information
+ *  @return -1 if the receiver does not support sync call, otherwise
+ *  @return the number of bytes of the return value of the call
+ *
+ */
+__attribute__((eosio_wasm_import))
+int64_t call(capi_name receiver, uint64_t flags, const char* data, size_t data_size);
+
+/**
+ * Copy up to `len` bytes of the return value of the most recent call to `mem`,
+ * in the context of this call's parent action or parent call
+ *
+ *  @brief Copy the return value of the most recent call to the specified location
+ *  @param mem - a pointer where up to `len` bytes of the return value will be copied
+ *  @param len - length of the return value to be copied
+ *  @return the number of bytes of the return value that can be retrieved (the number of total bytes of return value)
+ */
+__attribute__((eosio_wasm_import))
+uint32_t get_call_return_value( void* mem, uint32_t len );
+
+/**
+ *  Copy up to `len` bytes of the current call data to `mem`
+ *
+ *  @brief Copy current call data to the specified location
+ *  @param mem - a pointer where up to `len` bytes of the current call data will be copied
+ *  @param len - length of the current call data to be copied
+ *  @return the number of bytes of the data that can be retrieved (the number of total bytes of the data)
+ */
+__attribute__((eosio_wasm_import))
+uint32_t get_call_data( void* mem, uint32_t len );
+
+/**
+ * Set the return value from `mem` with `len` bytes. This is to be retrieved by parent action
+ * or parent call using `set_call_return_value`
+ *
+ *  @brief Copy the return value from the specified location
+ *  @param mem - a pointer where `len` bytes of the return value will be copied from
+ */
+__attribute__((eosio_wasm_import))
+void set_call_return_value( void* mem, uint32_t len );
+
+#ifdef __cplusplus
+}
+#endif
+/// @} call

--- a/libraries/eosiolib/contracts/eosio/call.hpp
+++ b/libraries/eosiolib/contracts/eosio/call.hpp
@@ -1,0 +1,102 @@
+/**
+ *  @file
+ */
+#pragma once
+#include <cstdlib>
+#include <type_traits>
+
+#include "../../core/eosio/serialize.hpp"
+#include "../../core/eosio/datastream.hpp"
+#include "../../core/eosio/name.hpp"
+#include "../../core/eosio/fixed_bytes.hpp"
+#include "../../core/eosio/ignore.hpp"
+#include "../../core/eosio/time.hpp"
+
+namespace eosio {
+
+   namespace internal_use_do_not_use {
+      extern "C" {
+         __attribute__((eosio_wasm_import))
+         int64_t call(uint64_t receiver, uint64_t flags, const char* data, size_t data_size);
+
+         __attribute__((eosio_wasm_import))
+         uint32_t get_call_return_value( void* mem, uint32_t len );
+
+         __attribute__((eosio_wasm_import))
+         uint32_t get_call_data( void* mem, uint32_t len );
+
+         __attribute__((eosio_wasm_import))
+         void set_call_return_value( void* mem, uint32_t len );
+      }
+   };
+
+   /**
+    *  @defgroup call call
+    *  @ingroup contracts
+    *  @brief Defines type-safe C++ wrappers for querying call and sending call
+    *  @note There are some methods from the @ref call that can be used directly from C++
+    */
+
+   inline uint32_t get_call_return_value( void* mem, uint32_t len ) {
+     return internal_use_do_not_use::get_call_return_value(mem, len);
+   }
+
+   inline uint32_t get_call_data( void* mem, uint32_t len ) {
+     return internal_use_do_not_use::get_call_data(mem, len);
+   }
+
+   inline void set_call_return_value( void* mem, uint32_t len ) {
+     internal_use_do_not_use::set_call_return_value(mem, len);
+   }
+
+   /**
+    *  This is the packed representation of a call
+    *
+    *  @ingroup call
+    */
+   struct call {
+      /**
+       *  Name of the account the call is intended for
+       */
+      name               receiver;
+
+      /**
+       *  flags indicating call properties, like read only request
+       */
+      uint64_t           flags;
+
+      /**
+       *  Payload data
+       */
+      std::vector<char>  data;
+
+      /**
+       *  Default Constructor
+       */
+      call() = default;
+
+      /**
+       * Construct a new call object with receiver, name, and payload data
+       *
+       * @tparam T  - Type of call data, must be serializable by `pack(...)`
+       * @param receiver -  The name of the account this call is intended for
+       * @param flags - The flags
+       * @param value - The call data that will be serialized via pack into data
+       */
+      template<typename T>
+      call( struct name receiver, uint64_t flags, T&& value )
+      :receiver(receiver), flags(flags), data(pack(std::forward<T>(value))) {}
+
+      /// @cond INTERNAL
+      EOSLIB_SERIALIZE( call, (receiver)(flags)(data) )
+      /// @endcond
+
+      /**
+       * Make a call using the functor operator
+       */
+      int64_t operator()() const {
+         return internal_use_do_not_use::call(receiver.value, flags, data.data(), data.size());
+      }
+   };
+
+} // namespace eosio

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -17,334 +17,346 @@
 using namespace eosio::native;
 extern "C" {
    void get_resource_limits( capi_name account, int64_t* ram_bytes, int64_t* net_weight, int64_t* cpu_weight ) {
-      return intrinsics::get().call<intrinsics::get_resource_limits>(account, ram_bytes, net_weight, cpu_weight);
+      return intrinsics::get().exec<intrinsics::get_resource_limits>(account, ram_bytes, net_weight, cpu_weight);
    }
    void set_resource_limits( capi_name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight ) {
-      return intrinsics::get().call<intrinsics::set_resource_limits>(account, ram_bytes, net_weight, cpu_weight);
+      return intrinsics::get().exec<intrinsics::set_resource_limits>(account, ram_bytes, net_weight, cpu_weight);
    }
    int64_t set_proposed_producers( char *producer_data, uint32_t producer_data_size ) {
-      return intrinsics::get().call<intrinsics::set_proposed_producers>(producer_data, producer_data_size);
+      return intrinsics::get().exec<intrinsics::set_proposed_producers>(producer_data, producer_data_size);
    }
    int64_t set_proposed_producers_ex( uint64_t producer_data_format, char *producer_data, uint32_t producer_data_size ) {
-      return intrinsics::get().call<intrinsics::set_proposed_producers_ex>(producer_data_format, producer_data, producer_data_size);
+      return intrinsics::get().exec<intrinsics::set_proposed_producers_ex>(producer_data_format, producer_data, producer_data_size);
    }
    uint32_t get_blockchain_parameters_packed( char* data, uint32_t datalen ) {
-      return intrinsics::get().call<intrinsics::get_blockchain_parameters_packed>(data, datalen);
+      return intrinsics::get().exec<intrinsics::get_blockchain_parameters_packed>(data, datalen);
    }
    void set_blockchain_parameters_packed( char* data, uint32_t datalen ) {
-      return intrinsics::get().call<intrinsics::set_blockchain_parameters_packed>(data, datalen);
+      return intrinsics::get().exec<intrinsics::set_blockchain_parameters_packed>(data, datalen);
    }
    bool is_privileged( capi_name account ) {
-      return intrinsics::get().call<intrinsics::is_privileged>(account);
+      return intrinsics::get().exec<intrinsics::is_privileged>(account);
    }
    void set_privileged( capi_name account, bool is_priv ) {
-      return intrinsics::get().call<intrinsics::set_privileged>(account, is_priv);
+      return intrinsics::get().exec<intrinsics::set_privileged>(account, is_priv);
    }
    bool is_feature_activated( const capi_checksum256* feature_digest ) {
-      return intrinsics::get().call<intrinsics::is_feature_activated>(feature_digest);
+      return intrinsics::get().exec<intrinsics::is_feature_activated>(feature_digest);
    }
    void preactivate_feature( const capi_checksum256* feature_digest ) {
-      return intrinsics::get().call<intrinsics::preactivate_feature>(feature_digest);
+      return intrinsics::get().exec<intrinsics::preactivate_feature>(feature_digest);
    }
    uint32_t get_active_producers( capi_name* producers, uint32_t datalen ) {
-      return intrinsics::get().call<intrinsics::get_active_producers>(producers, datalen);
+      return intrinsics::get().exec<intrinsics::get_active_producers>(producers, datalen);
    }
    int32_t db_idx64_store(uint64_t scope, capi_name table, capi_name payer, uint64_t id, const uint64_t* secondary) {
-      return intrinsics::get().call<intrinsics::db_idx64_store>(scope, table, payer, id, secondary);
+      return intrinsics::get().exec<intrinsics::db_idx64_store>(scope, table, payer, id, secondary);
    }
    void db_idx64_remove(int32_t iterator) {
-      return intrinsics::get().call<intrinsics::db_idx64_remove>(iterator);
+      return intrinsics::get().exec<intrinsics::db_idx64_remove>(iterator);
    }
    void db_idx64_update(int32_t iterator, capi_name payer, const uint64_t* secondary) {
-      return intrinsics::get().call<intrinsics::db_idx64_update>(iterator, payer, secondary);
+      return intrinsics::get().exec<intrinsics::db_idx64_update>(iterator, payer, secondary);
    }
    int32_t db_idx64_find_primary(capi_name code, uint64_t scope, capi_name table, uint64_t* secondary, uint64_t primary) {
-      return intrinsics::get().call<intrinsics::db_idx64_find_primary>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx64_find_primary>(code, scope, table, secondary, primary);
    }
    int32_t db_idx64_find_secondary(capi_name code, uint64_t scope, capi_name table, const uint64_t* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx64_find_secondary>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx64_find_secondary>(code, scope, table, secondary, primary);
    }
    int32_t db_idx64_lowerbound(capi_name code, uint64_t scope, capi_name table, uint64_t* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx64_lowerbound>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx64_lowerbound>(code, scope, table, secondary, primary);
    }
    int32_t db_idx64_upperbound(capi_name code, uint64_t scope, capi_name table, uint64_t* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx64_upperbound>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx64_upperbound>(code, scope, table, secondary, primary);
    }
    int32_t db_idx64_end(capi_name code, uint64_t scope, capi_name table) {
-      return intrinsics::get().call<intrinsics::db_idx64_end>(code, scope, table);
+      return intrinsics::get().exec<intrinsics::db_idx64_end>(code, scope, table);
    }
    int32_t db_idx64_next(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx64_next>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx64_next>(iterator, primary);
    }
    int32_t db_idx64_previous(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx64_previous>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx64_previous>(iterator, primary);
    }
    int32_t db_idx128_store(uint64_t scope, capi_name table, capi_name payer, uint64_t id, const uint128_t* secondary) {
-      return intrinsics::get().call<intrinsics::db_idx128_store>(scope, table, payer, id, secondary);
+      return intrinsics::get().exec<intrinsics::db_idx128_store>(scope, table, payer, id, secondary);
    }
    void db_idx128_remove(int32_t iterator) {
-      return intrinsics::get().call<intrinsics::db_idx128_remove>(iterator);
+      return intrinsics::get().exec<intrinsics::db_idx128_remove>(iterator);
    }
    void db_idx128_update(int32_t iterator, capi_name payer, const uint128_t* secondary) {
-      return intrinsics::get().call<intrinsics::db_idx128_update>(iterator, payer, secondary);
+      return intrinsics::get().exec<intrinsics::db_idx128_update>(iterator, payer, secondary);
    }
    int32_t db_idx128_find_primary(capi_name code, uint64_t scope, capi_name table, uint128_t* secondary, uint64_t primary) {
-      return intrinsics::get().call<intrinsics::db_idx128_find_primary>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx128_find_primary>(code, scope, table, secondary, primary);
    }
    int32_t db_idx128_find_secondary(capi_name code, uint64_t scope, capi_name table, const uint128_t* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx128_find_secondary>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx128_find_secondary>(code, scope, table, secondary, primary);
    }
    int32_t db_idx128_lowerbound(capi_name code, uint64_t scope, capi_name table, uint128_t* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx128_lowerbound>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx128_lowerbound>(code, scope, table, secondary, primary);
    }
    int32_t db_idx128_upperbound(capi_name code, uint64_t scope, capi_name table, uint128_t* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx128_upperbound>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx128_upperbound>(code, scope, table, secondary, primary);
    }
    int32_t db_idx128_end(capi_name code, uint64_t scope, capi_name table) {
-      return intrinsics::get().call<intrinsics::db_idx128_end>(code, scope, table);
+      return intrinsics::get().exec<intrinsics::db_idx128_end>(code, scope, table);
    }
    int32_t db_idx128_next(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx128_next>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx128_next>(iterator, primary);
    }
    int32_t db_idx128_previous(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx128_previous>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx128_previous>(iterator, primary);
    }
    int32_t db_idx256_store(uint64_t scope, capi_name table, capi_name payer, uint64_t id, const uint128_t* data, uint32_t datalen) {
-      return intrinsics::get().call<intrinsics::db_idx256_store>(scope, table, payer, id, data, datalen);
+      return intrinsics::get().exec<intrinsics::db_idx256_store>(scope, table, payer, id, data, datalen);
    }
    void db_idx256_remove(int32_t iterator) {
-      return intrinsics::get().call<intrinsics::db_idx256_remove>(iterator);
+      return intrinsics::get().exec<intrinsics::db_idx256_remove>(iterator);
    }
    void db_idx256_update(int32_t iterator, capi_name payer, const uint128_t* data, uint32_t datalen) {
-      return intrinsics::get().call<intrinsics::db_idx256_update>(iterator, payer, data, datalen);
+      return intrinsics::get().exec<intrinsics::db_idx256_update>(iterator, payer, data, datalen);
    }
    int32_t db_idx256_find_primary(capi_name code, uint64_t scope, capi_name table, uint128_t* data, uint32_t datalen,  uint64_t primary) {
-      return intrinsics::get().call<intrinsics::db_idx256_find_primary>(code, scope, table, data, datalen, primary);
+      return intrinsics::get().exec<intrinsics::db_idx256_find_primary>(code, scope, table, data, datalen, primary);
    }
    int32_t db_idx256_find_secondary(capi_name code, uint64_t scope, capi_name table, const uint128_t* data, uint32_t datalen, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx256_find_secondary>(code, scope, table, data, datalen, primary);
+      return intrinsics::get().exec<intrinsics::db_idx256_find_secondary>(code, scope, table, data, datalen, primary);
    }
    int32_t db_idx256_lowerbound(capi_name code, uint64_t scope, capi_name table, uint128_t* data, uint32_t datalen, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx256_lowerbound>(code, scope, table, data, datalen, primary);
+      return intrinsics::get().exec<intrinsics::db_idx256_lowerbound>(code, scope, table, data, datalen, primary);
    }
    int32_t db_idx256_upperbound(capi_name code, uint64_t scope, capi_name table, uint128_t* data, uint32_t datalen,  uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx256_upperbound>(code, scope, table, data, datalen, primary);
+      return intrinsics::get().exec<intrinsics::db_idx256_upperbound>(code, scope, table, data, datalen, primary);
    }
    int32_t db_idx256_end(capi_name code, uint64_t scope, capi_name table) {
-      return intrinsics::get().call<intrinsics::db_idx256_end>(code, scope, table);
+      return intrinsics::get().exec<intrinsics::db_idx256_end>(code, scope, table);
    }
    int32_t db_idx256_next(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx256_next>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx256_next>(iterator, primary);
    }
    int32_t db_idx256_previous(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx256_previous>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx256_previous>(iterator, primary);
    }
    int32_t db_idx_double_store(uint64_t scope, capi_name table, capi_name payer, uint64_t id, const double* secondary) {
-      return intrinsics::get().call<intrinsics::db_idx_double_store>(scope, table, payer, id, secondary);
+      return intrinsics::get().exec<intrinsics::db_idx_double_store>(scope, table, payer, id, secondary);
    }
    void db_idx_double_remove(int32_t iterator) {
-      return intrinsics::get().call<intrinsics::db_idx_double_remove>(iterator);
+      return intrinsics::get().exec<intrinsics::db_idx_double_remove>(iterator);
    }
    void db_idx_double_update(int32_t iterator, capi_name payer, const double* secondary) {
-      return intrinsics::get().call<intrinsics::db_idx_double_update>(iterator, payer, secondary);
+      return intrinsics::get().exec<intrinsics::db_idx_double_update>(iterator, payer, secondary);
    }
    int32_t db_idx_double_find_primary(capi_name code, uint64_t scope, capi_name table, double* secondary, uint64_t primary) {
-      return intrinsics::get().call<intrinsics::db_idx_double_find_primary>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_double_find_primary>(code, scope, table, secondary, primary);
    }
    int32_t db_idx_double_find_secondary(capi_name code, uint64_t scope, capi_name table, const double* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_double_find_secondary>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_double_find_secondary>(code, scope, table, secondary, primary);
    }
    int32_t db_idx_double_lowerbound(capi_name code, uint64_t scope, capi_name table, double* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_double_lowerbound>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_double_lowerbound>(code, scope, table, secondary, primary);
    }
    int32_t db_idx_double_upperbound(capi_name code, uint64_t scope, capi_name table, double* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_double_upperbound>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_double_upperbound>(code, scope, table, secondary, primary);
    }
    int32_t db_idx_double_end(capi_name code, uint64_t scope, capi_name table) {
-      return intrinsics::get().call<intrinsics::db_idx_double_end>(code, scope, table);
+      return intrinsics::get().exec<intrinsics::db_idx_double_end>(code, scope, table);
    }
    int32_t db_idx_double_next(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_double_next>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_double_next>(iterator, primary);
    }
    int32_t db_idx_double_previous(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_double_previous>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_double_previous>(iterator, primary);
    }
    int32_t db_idx_long_double_store(uint64_t scope, capi_name table, capi_name payer, uint64_t id, const long double* secondary) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_store>(scope, table, payer, id, secondary);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_store>(scope, table, payer, id, secondary);
    }
    void db_idx_long_double_remove(int32_t iterator) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_remove>(iterator);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_remove>(iterator);
    }
    void db_idx_long_double_update(int32_t iterator, capi_name payer, const long double* secondary) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_update>(iterator, payer, secondary);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_update>(iterator, payer, secondary);
    }
    int32_t db_idx_long_double_find_primary(capi_name code, uint64_t scope, capi_name table, long double* secondary, uint64_t primary) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_find_primary>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_find_primary>(code, scope, table, secondary, primary);
    }
    int32_t db_idx_long_double_find_secondary(capi_name code, uint64_t scope, capi_name table, const long double* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_find_secondary>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_find_secondary>(code, scope, table, secondary, primary);
    }
    int32_t db_idx_long_double_lowerbound(capi_name code, uint64_t scope, capi_name table, long double* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_lowerbound>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_lowerbound>(code, scope, table, secondary, primary);
    }
    int32_t db_idx_long_double_upperbound(capi_name code, uint64_t scope, capi_name table, long double* secondary, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_upperbound>(code, scope, table, secondary, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_upperbound>(code, scope, table, secondary, primary);
    }
    int32_t db_idx_long_double_end(capi_name code, uint64_t scope, capi_name table) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_end>(code, scope, table);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_end>(code, scope, table);
    }
    int32_t db_idx_long_double_next(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_next>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_next>(iterator, primary);
    }
    int32_t db_idx_long_double_previous(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_idx_long_double_previous>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_idx_long_double_previous>(iterator, primary);
    }
    int32_t db_store_i64(uint64_t scope, capi_name table, capi_name payer, uint64_t id,  const void* data, uint32_t len) {
-      return intrinsics::get().call<intrinsics::db_store_i64>(scope, table, payer, id, data, len);
+      return intrinsics::get().exec<intrinsics::db_store_i64>(scope, table, payer, id, data, len);
    }
    void db_update_i64(int32_t iterator, capi_name payer, const void* data, uint32_t len) {
-      return intrinsics::get().call<intrinsics::db_update_i64>(iterator, payer, data, len);
+      return intrinsics::get().exec<intrinsics::db_update_i64>(iterator, payer, data, len);
    }
    void db_remove_i64(int32_t iterator) {
-      return intrinsics::get().call<intrinsics::db_remove_i64>(iterator);
+      return intrinsics::get().exec<intrinsics::db_remove_i64>(iterator);
    }
    int32_t db_get_i64(int32_t iterator, const void* data, uint32_t len) {
-      return intrinsics::get().call<intrinsics::db_get_i64>(iterator, data, len);
+      return intrinsics::get().exec<intrinsics::db_get_i64>(iterator, data, len);
    }
    int32_t db_next_i64(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_next_i64>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_next_i64>(iterator, primary);
    }
    int32_t db_previous_i64(int32_t iterator, uint64_t* primary) {
-      return intrinsics::get().call<intrinsics::db_previous_i64>(iterator, primary);
+      return intrinsics::get().exec<intrinsics::db_previous_i64>(iterator, primary);
    }
    int32_t db_find_i64(capi_name code, uint64_t scope, capi_name table, uint64_t id) {
-      return intrinsics::get().call<intrinsics::db_find_i64>(code, scope, table, id);
+      return intrinsics::get().exec<intrinsics::db_find_i64>(code, scope, table, id);
    }
    int32_t db_lowerbound_i64(capi_name code, uint64_t scope, capi_name table, uint64_t id) {
-      return intrinsics::get().call<intrinsics::db_lowerbound_i64>(code, scope, table, id);
+      return intrinsics::get().exec<intrinsics::db_lowerbound_i64>(code, scope, table, id);
    }
    int32_t db_upperbound_i64(capi_name code, uint64_t scope, capi_name table, uint64_t id) {
-      return intrinsics::get().call<intrinsics::db_upperbound_i64>(code, scope, table, id);
+      return intrinsics::get().exec<intrinsics::db_upperbound_i64>(code, scope, table, id);
    }
    int32_t db_end_i64(capi_name code, uint64_t scope, capi_name table) {
-      return intrinsics::get().call<intrinsics::db_end_i64>(code, scope, table);
+      return intrinsics::get().exec<intrinsics::db_end_i64>(code, scope, table);
    }
    void assert_recover_key( const capi_checksum256* digest, const char* sig, size_t siglen, const char* pub, size_t publen ) {
-      return intrinsics::get().call<intrinsics::assert_recover_key>(digest, sig, siglen, pub, publen);
+      return intrinsics::get().exec<intrinsics::assert_recover_key>(digest, sig, siglen, pub, publen);
    }
    int recover_key( const capi_checksum256* digest, const char* sig, size_t siglen, char* pub, size_t publen ) {
-      return intrinsics::get().call<intrinsics::recover_key>(digest, sig, siglen, pub, publen);
+      return intrinsics::get().exec<intrinsics::recover_key>(digest, sig, siglen, pub, publen);
    }
    void assert_sha256( const char* data, uint32_t length, const capi_checksum256* hash ) {
-      return intrinsics::get().call<intrinsics::assert_sha256>(data, length, hash);
+      return intrinsics::get().exec<intrinsics::assert_sha256>(data, length, hash);
    }
    void assert_sha1( const char* data, uint32_t length, const capi_checksum160* hash ) {
-      return intrinsics::get().call<intrinsics::assert_sha1>(data, length, hash);
+      return intrinsics::get().exec<intrinsics::assert_sha1>(data, length, hash);
    }
    void assert_sha512( const char* data, uint32_t length, const capi_checksum512* hash ) {
-      return intrinsics::get().call<intrinsics::assert_sha512>(data, length, hash);
+      return intrinsics::get().exec<intrinsics::assert_sha512>(data, length, hash);
    }
    void assert_ripemd160( const char* data, uint32_t length, const capi_checksum160* hash ) {
-      return intrinsics::get().call<intrinsics::assert_ripemd160>(data, length, hash);
+      return intrinsics::get().exec<intrinsics::assert_ripemd160>(data, length, hash);
    }
    void sha256( const char* data, uint32_t length, capi_checksum256* hash ) {
-      return intrinsics::get().call<intrinsics::sha256>(data, length, hash);
+      return intrinsics::get().exec<intrinsics::sha256>(data, length, hash);
    }
    void sha1( const char* data, uint32_t length, capi_checksum160* hash ) {
-      return intrinsics::get().call<intrinsics::sha1>(data, length, hash);
+      return intrinsics::get().exec<intrinsics::sha1>(data, length, hash);
    }
    void sha512( const char* data, uint32_t length, capi_checksum512* hash ) {
-      return intrinsics::get().call<intrinsics::sha512>(data, length, hash);
+      return intrinsics::get().exec<intrinsics::sha512>(data, length, hash);
    }
    void ripemd160( const char* data, uint32_t length, capi_checksum160* hash ) {
-      return intrinsics::get().call<intrinsics::ripemd160>(data, length, hash);
+      return intrinsics::get().exec<intrinsics::ripemd160>(data, length, hash);
    }
    int32_t check_transaction_authorization( const char* trx_data,     uint32_t trx_size,
                                     const char* pubkeys_data, uint32_t pubkeys_size,
                                     const char* perms_data,   uint32_t perms_size
                                   ) {
-      return intrinsics::get().call<intrinsics::check_transaction_authorization>(trx_data, trx_size, pubkeys_data, pubkeys_size, perms_data, perms_size);
+      return intrinsics::get().exec<intrinsics::check_transaction_authorization>(trx_data, trx_size, pubkeys_data, pubkeys_size, perms_data, perms_size);
    }
    int32_t check_permission_authorization( capi_name account, capi_name permission,
                                     const char* pubkeys_data, uint32_t pubkeys_size,
                                     const char* perms_data,   uint32_t perms_size, uint64_t delay_us
                                   ) {
-      return intrinsics::get().call<intrinsics::check_permission_authorization>(account, permission, pubkeys_data, pubkeys_size, perms_data, perms_size, delay_us);
+      return intrinsics::get().exec<intrinsics::check_permission_authorization>(account, permission, pubkeys_data, pubkeys_size, perms_data, perms_size, delay_us);
    }
    int64_t get_permission_last_used( capi_name account, capi_name permission ) {
-      return intrinsics::get().call<intrinsics::get_permission_last_used>(account, permission);
+      return intrinsics::get().exec<intrinsics::get_permission_last_used>(account, permission);
    }
    int64_t get_account_creation_time( capi_name account ) {
-      return intrinsics::get().call<intrinsics::get_account_creation_time>(account);
+      return intrinsics::get().exec<intrinsics::get_account_creation_time>(account);
    }
    uint64_t  current_time() {
-      return intrinsics::get().call<intrinsics::current_time>();
+      return intrinsics::get().exec<intrinsics::current_time>();
    }
    uint64_t  publication_time() {
-      return intrinsics::get().call<intrinsics::publication_time>();
+      return intrinsics::get().exec<intrinsics::publication_time>();
    }
    uint32_t read_action_data( void* msg, uint32_t len ) {
-      return intrinsics::get().call<intrinsics::read_action_data>(msg, len);
+      return intrinsics::get().exec<intrinsics::read_action_data>(msg, len);
    }
    uint32_t action_data_size() {
-      return intrinsics::get().call<intrinsics::action_data_size>();
+      return intrinsics::get().exec<intrinsics::action_data_size>();
    }
    capi_name current_receiver() {
-      return intrinsics::get().call<intrinsics::current_receiver>();
+      return intrinsics::get().exec<intrinsics::current_receiver>();
    }
    void set_action_return_value( void* rv, size_t len ) {
-      intrinsics::get().call<intrinsics::set_action_return_value>(rv, len);
+      intrinsics::get().exec<intrinsics::set_action_return_value>(rv, len);
    }
    void require_recipient( capi_name name ) {
-      return intrinsics::get().call<intrinsics::require_recipient>(name);
+      return intrinsics::get().exec<intrinsics::require_recipient>(name);
    }
    void require_auth( capi_name name ) {
-      return intrinsics::get().call<intrinsics::require_auth>(name);
+      return intrinsics::get().exec<intrinsics::require_auth>(name);
    }
    void require_auth2( capi_name name, capi_name permission ) {
-      return intrinsics::get().call<intrinsics::require_auth2>(name, permission);
+      return intrinsics::get().exec<intrinsics::require_auth2>(name, permission);
    }
    bool has_auth( capi_name name ) {
-      return intrinsics::get().call<intrinsics::has_auth>(name);
+      return intrinsics::get().exec<intrinsics::has_auth>(name);
    }
    bool is_account( capi_name name ) {
-      return intrinsics::get().call<intrinsics::is_account>(name);
+      return intrinsics::get().exec<intrinsics::is_account>(name);
    }
    size_t read_transaction(char *buffer, size_t size) {
-      return intrinsics::get().call<intrinsics::read_transaction>(buffer, size);
+      return intrinsics::get().exec<intrinsics::read_transaction>(buffer, size);
    }
    size_t transaction_size() {
-      return intrinsics::get().call<intrinsics::transaction_size>();
+      return intrinsics::get().exec<intrinsics::transaction_size>();
    }
    uint32_t expiration() {
-      return intrinsics::get().call<intrinsics::expiration>();
+      return intrinsics::get().exec<intrinsics::expiration>();
    }
    int tapos_block_prefix() {
-      return intrinsics::get().call<intrinsics::tapos_block_prefix>();
+      return intrinsics::get().exec<intrinsics::tapos_block_prefix>();
    }
    int tapos_block_num() {
-      return intrinsics::get().call<intrinsics::tapos_block_num>();
+      return intrinsics::get().exec<intrinsics::tapos_block_num>();
    }
    int get_action( uint32_t type, uint32_t index, char* buff, size_t size ) {
-      return intrinsics::get().call<intrinsics::get_action>(type, index, buff, size);
+      return intrinsics::get().exec<intrinsics::get_action>(type, index, buff, size);
    }
    void send_inline(char *serialized_action, size_t size) {
-      return intrinsics::get().call<intrinsics::send_inline>(serialized_action, size);
+      return intrinsics::get().exec<intrinsics::send_inline>(serialized_action, size);
    }
    void send_context_free_inline(char *serialized_action, size_t size) {
-      return intrinsics::get().call<intrinsics::send_context_free_inline>(serialized_action, size);
+      return intrinsics::get().exec<intrinsics::send_context_free_inline>(serialized_action, size);
    }
    void send_deferred(const uint128_t* sender_id, capi_name payer, const char *serialized_transaction, size_t size, uint32_t replace_existing) {
-      return intrinsics::get().call<intrinsics::send_deferred>(sender_id, payer, serialized_transaction, size, replace_existing);
+      return intrinsics::get().exec<intrinsics::send_deferred>(sender_id, payer, serialized_transaction, size, replace_existing);
    }
    int cancel_deferred(const uint128_t* sender_id) {
-      return intrinsics::get().call<intrinsics::cancel_deferred>(sender_id);
+      return intrinsics::get().exec<intrinsics::cancel_deferred>(sender_id);
    }
    int get_context_free_data( uint32_t index, char* buff, size_t size ) {
-      return intrinsics::get().call<intrinsics::get_context_free_data>(index, buff, size);
+      return intrinsics::get().exec<intrinsics::get_context_free_data>(index, buff, size);
    }
    capi_name get_sender() {
-      return intrinsics::get().call<intrinsics::get_sender>();
+      return intrinsics::get().exec<intrinsics::get_sender>();
+   }
+   int64_t call(capi_name receiver, uint64_t flags, const char* data, size_t data_size) {
+      return intrinsics::get().exec<intrinsics::call>(receiver, flags, data, data_size);
+   }
+   uint32_t get_call_return_value(void* mem, uint32_t len) {
+      return intrinsics::get().exec<intrinsics::get_call_return_value>(mem, len);
+   }
+   uint32_t get_call_data(void* mem, uint32_t len) {
+      return intrinsics::get().exec<intrinsics::get_call_data>(mem, len);
+   }
+   void set_call_return_value(void* mem, uint32_t len) {
+      return intrinsics::get().exec<intrinsics::set_call_return_value>(mem, len);
    }
 
    // softfloat
@@ -786,47 +798,47 @@ extern "C" {
    }
 
    void prints_l(const char* cstr, uint32_t len) {
-      return intrinsics::get().call<intrinsics::prints_l>(cstr, len);
+      return intrinsics::get().exec<intrinsics::prints_l>(cstr, len);
    }
 
    void prints(const char* cstr) {
-      return intrinsics::get().call<intrinsics::prints>(cstr);
+      return intrinsics::get().exec<intrinsics::prints>(cstr);
    }
 
    void printi(int64_t value) {
-      return intrinsics::get().call<intrinsics::printi>(value);
+      return intrinsics::get().exec<intrinsics::printi>(value);
    }
 
    void printui(uint64_t value) {
-      return intrinsics::get().call<intrinsics::printui>(value);
+      return intrinsics::get().exec<intrinsics::printui>(value);
    }
 
    void printi128(const int128_t* value) {
-      return intrinsics::get().call<intrinsics::printi128>(value);
+      return intrinsics::get().exec<intrinsics::printi128>(value);
    }
 
     void printui128(const uint128_t* value) {
-      return intrinsics::get().call<intrinsics::printui128>(value);
+      return intrinsics::get().exec<intrinsics::printui128>(value);
    }
 
    void printsf(float value) {
-      return intrinsics::get().call<intrinsics::printsf>(value);
+      return intrinsics::get().exec<intrinsics::printsf>(value);
    }
 
    void printdf(double value) {
-      return intrinsics::get().call<intrinsics::printdf>(value);
+      return intrinsics::get().exec<intrinsics::printdf>(value);
    }
 
    void printqf(const long double* value) {
-      return intrinsics::get().call<intrinsics::printqf>(value);
+      return intrinsics::get().exec<intrinsics::printqf>(value);
    }
 
    void printn(uint64_t nm) {
-      return intrinsics::get().call<intrinsics::printn>(nm);
+      return intrinsics::get().exec<intrinsics::printn>(nm);
    }
 
    void printhex(const void* data, uint32_t len) {
-      return intrinsics::get().call<intrinsics::printhex>(data, len);
+      return intrinsics::get().exec<intrinsics::printhex>(data, len);
    }
 
    void* memset ( void* ptr, int value, size_t num ) {
@@ -891,86 +903,86 @@ extern "C" {
 #pragma clang diagnostic pop
 
    void set_finalizers(uint64_t packed_finalizer_format, const char* data, uint32_t len) {
-      intrinsics::get().call<intrinsics::set_finalizers>(packed_finalizer_format, data, len);
+      intrinsics::get().exec<intrinsics::set_finalizers>(packed_finalizer_format, data, len);
    }
   
 } // extern "C"
 
 int32_t blake2_f( uint32_t rounds, const char* state, uint32_t state_len, const char* msg, uint32_t msg_len, 
                   const char* t0_offset, uint32_t t0_len, const char* t1_offset, uint32_t t1_len, int32_t final, char* result, uint32_t result_len) {
-   return intrinsics::get().call<intrinsics::blake2_f>(rounds, state, state_len, msg, msg_len, t0_offset, t0_len, t1_offset, t1_len, final, result, result_len);
+   return intrinsics::get().exec<intrinsics::blake2_f>(rounds, state, state_len, msg, msg_len, t0_offset, t0_len, t1_offset, t1_len, final, result, result_len);
 }
 
 int32_t k1_recover( const char* sig, uint32_t sig_len, const char* dig, uint32_t dig_len, char* pub, uint32_t pub_len) {
-   return intrinsics::get().call<intrinsics::k1_recover>(sig, sig_len, dig, dig_len, pub, pub_len);
+   return intrinsics::get().exec<intrinsics::k1_recover>(sig, sig_len, dig, dig_len, pub, pub_len);
 }
 
 int32_t alt_bn128_add( const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* result, uint32_t result_len) {
-   return intrinsics::get().call<intrinsics::alt_bn128_add>(op1, op1_len, op2, op2_len, result, result_len);
+   return intrinsics::get().exec<intrinsics::alt_bn128_add>(op1, op1_len, op2, op2_len, result, result_len);
 }
 
 int32_t alt_bn128_mul( const char* g1, uint32_t g1_len, const char* scalar, uint32_t scalar_len, char* result, uint32_t result_len) {
-   return intrinsics::get().call<intrinsics::alt_bn128_mul>(g1, g1_len, scalar, scalar_len, result, result_len);
+   return intrinsics::get().exec<intrinsics::alt_bn128_mul>(g1, g1_len, scalar, scalar_len, result, result_len);
 }
 
 int32_t alt_bn128_pair( const char* pairs, uint32_t pairs_len) {
-   return intrinsics::get().call<intrinsics::alt_bn128_pair>(pairs, pairs_len);
+   return intrinsics::get().exec<intrinsics::alt_bn128_pair>(pairs, pairs_len);
 }
 
 int32_t mod_exp( const char* base, uint32_t base_len, const char* exp, uint32_t exp_len, const char* mod, uint32_t mod_len, char* result, uint32_t result_len) {
-   return intrinsics::get().call<intrinsics::mod_exp>(base, base_len, exp, exp_len, mod, mod_len, result, result_len);
+   return intrinsics::get().exec<intrinsics::mod_exp>(base, base_len, exp, exp_len, mod, mod_len, result, result_len);
 }
 
 void sha3( const char* data, uint32_t data_len, char* hash, uint32_t hash_len, int32_t keccak ) {
-   intrinsics::get().call<intrinsics::sha3>(data, data_len, hash, hash_len, keccak);
+   intrinsics::get().exec<intrinsics::sha3>(data, data_len, hash, hash_len, keccak);
 }
 
 int32_t bls_g1_add(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len)
 {
-    return intrinsics::get().call<intrinsics::bls_g1_add>(op1, op1_len, op2, op2_len, res, res_len);
+    return intrinsics::get().exec<intrinsics::bls_g1_add>(op1, op1_len, op2, op2_len, res, res_len);
 }
 
 int32_t bls_g2_add(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len)
 {
-    return intrinsics::get().call<intrinsics::bls_g2_add>(op1, op1_len, op2, op2_len, res, res_len);
+    return intrinsics::get().exec<intrinsics::bls_g2_add>(op1, op1_len, op2, op2_len, res, res_len);
 }
 
 int32_t bls_g1_weighted_sum(const char* points, uint32_t points_len, const char* scalars, uint32_t scalars_len, uint32_t n, char* res, uint32_t res_len)
 {
-    return  intrinsics::get().call<intrinsics::bls_g1_weighted_sum>(points, points_len, scalars, scalars_len, n, res, res_len);
+    return  intrinsics::get().exec<intrinsics::bls_g1_weighted_sum>(points, points_len, scalars, scalars_len, n, res, res_len);
 }
 
 int32_t bls_g2_weighted_sum(const char* points, uint32_t points_len, const char* scalars, uint32_t scalars_len, uint32_t n, char* res, uint32_t res_len)
 {
-    return  intrinsics::get().call<intrinsics::bls_g2_weighted_sum>(points, points_len, scalars, scalars_len, n, res, res_len);
+    return  intrinsics::get().exec<intrinsics::bls_g2_weighted_sum>(points, points_len, scalars, scalars_len, n, res, res_len);
 }
 
 int32_t bls_pairing(const char* g1_points, uint32_t g1_points_len, const char* g2_points, uint32_t g2_points_len, uint32_t n, char* res, uint32_t res_len)
 {
-    return intrinsics::get().call<intrinsics::bls_pairing>(g1_points, g1_points_len, g1_points, g1_points_len, n, res, res_len);
+    return intrinsics::get().exec<intrinsics::bls_pairing>(g1_points, g1_points_len, g1_points, g1_points_len, n, res, res_len);
 }
 
 int32_t bls_g1_map(const char* e, uint32_t e_len, char* res, uint32_t res_len)
 {
-    return intrinsics::get().call<intrinsics::bls_g1_map>(e, e_len, res, res_len);
+    return intrinsics::get().exec<intrinsics::bls_g1_map>(e, e_len, res, res_len);
 }
 
 int32_t bls_g2_map(const char* e, uint32_t e_len, char* res, uint32_t res_len)
 {
-    return intrinsics::get().call<intrinsics::bls_g2_map>(e, e_len, res, res_len);
+    return intrinsics::get().exec<intrinsics::bls_g2_map>(e, e_len, res, res_len);
 }
 
 int32_t bls_fp_mod(const char* s, uint32_t s_len, char* res, uint32_t res_len)
 {
-    return intrinsics::get().call<intrinsics::bls_fp_mod>(s, s_len, res, res_len);
+    return intrinsics::get().exec<intrinsics::bls_fp_mod>(s, s_len, res, res_len);
 }
 
 int32_t bls_fp_mul(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len)
 {
-    return  intrinsics::get().call<intrinsics::bls_fp_mul>(op1, op1_len, op2, op2_len, res, res_len);
+    return  intrinsics::get().exec<intrinsics::bls_fp_mul>(op1, op1_len, op2, op2_len, res, res_len);
 }
 
 int32_t bls_fp_exp(const char* base, uint32_t base_len, const char* exp, uint32_t exp_len, char* res, uint32_t res_len)
 {
-    return  intrinsics::get().call<intrinsics::bls_fp_exp>(base, base_len, exp, exp_len, res, res_len);
+    return  intrinsics::get().exec<intrinsics::bls_fp_exp>(base, base_len, exp, exp_len, res, res_len);
 }

--- a/libraries/native/native/eosio/intrinsics.hpp
+++ b/libraries/native/native/eosio/intrinsics.hpp
@@ -24,7 +24,7 @@ namespace eosio { namespace native {
          };
 
          template <intrinsic_name IN, typename... Args>
-         auto call(Args... args) -> decltype(std::get<IN>(intrinsics::get().funcs)(args...)) {
+         auto exec(Args... args) -> decltype(std::get<IN>(intrinsics::get().funcs)(args...)) {
             return std::get<IN>(intrinsics::get().funcs)(args...); 
          }
 

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -7,6 +7,7 @@
 #include <eosio/crypto_bls_ext.h>
 #include <eosio/db.h>
 #include <eosio/instant_finality.h>
+#include <eosio/call.h>
 #include <eosio/permission.h>
 #include <eosio/print.h>
 #include <eosio/privileged.h>
@@ -180,7 +181,11 @@ intrinsic_macro(bls_g2_map) \
 intrinsic_macro(bls_fp_mod) \
 intrinsic_macro(bls_fp_mul) \
 intrinsic_macro(bls_fp_exp) \
-intrinsic_macro(set_finalizers)
+intrinsic_macro(set_finalizers) \
+intrinsic_macro(call) \
+intrinsic_macro(get_call_return_value) \
+intrinsic_macro(get_call_data) \
+intrinsic_macro(set_call_return_value)
 
 #define CREATE_ENUM(name) \
    name,

--- a/tests/integration/call_tests.cpp
+++ b/tests/integration/call_tests.cpp
@@ -1,0 +1,29 @@
+#include <boost/test/unit_test.hpp>
+
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+#include <fc/variant_object.hpp>
+
+#include <contracts.hpp>
+
+using namespace eosio;
+using namespace eosio::testing;
+using namespace fc;
+
+using mvo = fc::mutable_variant_object;
+
+BOOST_AUTO_TEST_SUITE(call_tests)
+
+BOOST_FIXTURE_TEST_CASE(basic_test, tester) try {
+    create_accounts({ "calltests"_n });
+    produce_block();
+
+    set_code("calltests"_n, contracts::call_test_wasm());
+    set_abi("calltests"_n, contracts::call_test_abi().data());
+
+    produce_block();
+
+    BOOST_REQUIRE_NO_THROW(push_action("calltests"_n, "basictest"_n, "calltests"_n, {}));
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/integration/contracts.hpp.in
+++ b/tests/integration/contracts.hpp.in
@@ -39,5 +39,8 @@ namespace eosio::testing {
 
       static std::vector<uint8_t> test_multi_index_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../unit/test_contracts/test_multi_index.wasm"); }
       static std::vector<char>    test_multi_index_abi() { return read_abi("${CMAKE_BINARY_DIR}/../unit/test_contracts/test_multi_index.abi"); }
+      
+      static std::vector<uint8_t> call_test_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../unit/test_contracts/call_tests.wasm"); }
+      static std::vector<char>    call_test_abi() { return read_abi("${CMAKE_BINARY_DIR}/../unit/test_contracts/call_tests.abi"); }
    };
 } //ns eosio::testing

--- a/tests/unit/test_contracts/CMakeLists.txt
+++ b/tests/unit/test_contracts/CMakeLists.txt
@@ -13,8 +13,9 @@ add_contract(get_code_hash_tests get_code_hash_write get_code_hash_write.cpp)
 add_contract(get_code_hash_tests get_code_hash_read get_code_hash_read.cpp)
 add_contract(name_pk_tests name_pk_tests name_pk_tests.cpp)
 add_contract(test_multi_index test_multi_index multi_index_tests.cpp)
+add_contract(call_tests call_tests call_tests.cpp)
 add_contract(capi_tests capi_tests capi/capi.c capi/action.c capi/chain.c capi/crypto.c capi/db.c capi/permission.c
-                                   capi/print.c capi/privileged.c capi/system.c capi/transaction.c)
+                                   capi/print.c capi/privileged.c capi/system.c capi/transaction.c capi/call.c)
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/simple_wrong.abi ${CMAKE_CURRENT_BINARY_DIR}/simple_wrong.abi COPYONLY )
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/capi/capi_tests.abi ${CMAKE_CURRENT_BINARY_DIR}/capi_tests.abi COPYONLY )

--- a/tests/unit/test_contracts/call_tests.cpp
+++ b/tests/unit/test_contracts/call_tests.cpp
@@ -1,0 +1,20 @@
+#include <eosio/eosio.hpp>
+#include <eosio/call.hpp>
+
+class [[eosio::contract]] call_tests : public eosio::contract{
+public:
+   using contract::contract;
+
+   [[eosio::action]]
+   void basictest() {
+      std::vector<char> data{};
+      auto rc = eosio::call("calltests"_n, 0, data)();
+      // For now, because call dispatcher has not been implemented yet, call should return -1
+      eosio::check(rc == -1, "call did not return -1");
+
+      std::vector<char> value(10);
+      auto size = eosio::get_call_return_value(value.data(), value.size());
+      // call was not executed. return value size should be 0
+      eosio::check(size == 0, "return value size is not 0");
+   }
+};

--- a/tests/unit/test_contracts/capi/call.c
+++ b/tests/unit/test_contracts/capi/call.c
@@ -1,0 +1,9 @@
+#include <eosio/call.h>
+#include <stddef.h>
+
+void test_call( void ) {
+   call(0, 0, NULL, 0);
+   get_call_return_value(NULL, 0);
+   get_call_data(NULL, 0);
+   set_call_return_value(NULL, 0);
+}

--- a/tests/unit/test_contracts/capi/capi.c
+++ b/tests/unit/test_contracts/capi/capi.c
@@ -9,6 +9,7 @@ void test_print( void );
 void test_privileged( void );
 void test_system( void );
 void test_transaction( void );
+void test_call( void );
 
 void apply( uint64_t a, uint64_t b, uint64_t c ) {
    if(a != 0xed234054a367196eull) return; // random value that should not be used
@@ -21,4 +22,5 @@ void apply( uint64_t a, uint64_t b, uint64_t c ) {
    test_privileged();
    test_system();
    test_transaction();
+   test_call();
 }

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -896,7 +896,11 @@ struct generation_utils {
          "send_deferred",
          "send_inline",
          "send_context_free_inline",
-         "set_finalizers"
+         "set_finalizers",
+         "call",
+         "get_call_return_value",
+         "get_call_data",
+         "set_call_return_value"
       };
 
       return write_host_funcs.count(func_decl->getNameInfo().getAsString()) >= 1;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This is the first PR of sync call support in CDT. Its purpose is to build the basic infrastructure and get things moving. More changes are in future PRs.

The PR implements the new host functions `call()`, `get_call_return_value()`, `get_call_data()`, and `set_call_return_value()`. A simple test shows `call()` and `get_call_return_value()` can get into `nodeos` host side and return back results. `get_call_data()` and `set_call_return_value()` cannot be tested at the moment.

Resolves https://github.com/AntelopeIO/cdt/issues/342


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
