### PR TITLE
SC: Generate `call` and `call_results` sections in ABI files for sync calls and bump ABI version to `1.3`

### DIFF
--- a/tests/toolchain/abigen-pass/action_results_test.json
+++ b/tests/toolchain/abigen-pass/action_results_test.json
@@ -1,6 +1,7 @@
 {
    "tests" : [
       {
+         "compile_flags": ["--abi-version=1.2"],
          "expected" : {
             "abi-file" : "action_results_test.abi"
          }

--- a/tests/toolchain/abigen-pass/aliased_type_variant_template_arg.json
+++ b/tests/toolchain/abigen-pass/aliased_type_variant_template_arg.json
@@ -1,6 +1,7 @@
 {
     "tests": [
         {
+            "compile_flags": ["--abi-version=1.2"],
             "expected": {
                 "abi-file": "aliased_type_variant_template_arg.abi"
             }

--- a/tests/toolchain/abigen-pass/nested_container.json
+++ b/tests/toolchain/abigen-pass/nested_container.json
@@ -1,6 +1,7 @@
 {
     "tests" : [
        {
+          "compile_flags": ["--abi-version=1.2"],
           "expected" : {
              "abi-file" : "nested_container.abi"
           }

--- a/tests/toolchain/abigen-pass/ricardian_contract_test.json
+++ b/tests/toolchain/abigen-pass/ricardian_contract_test.json
@@ -1,7 +1,7 @@
 {
    "tests" : [
       {
-         "compile_flags" : ["-R={cwd}"],
+         "compile_flags" : ["--abi-version=1.2", "-R={cwd}"],
          "expected" : {
             "abi-file" : "ricardian_contract_test.abi"
          }

--- a/tests/toolchain/abigen-pass/singleton_contract.json
+++ b/tests/toolchain/abigen-pass/singleton_contract.json
@@ -1,10 +1,10 @@
 {
     "tests" : [
        {
+          "compile_flags": ["--abi-version=1.2"],
           "expected" : {
              "abi-file" : "singleton_contract.abi"
           }
        }
     ]
  }
- 

--- a/tests/toolchain/abigen-pass/struct_base_typedefd.json
+++ b/tests/toolchain/abigen-pass/struct_base_typedefd.json
@@ -1,6 +1,7 @@
 {
     "tests": [
         {
+            "compile_flags": ["--abi-version=1.2"],
             "expected": {
                 "abi-file": "struct_base_typedefd.abi"
             }

--- a/tests/toolchain/abigen-pass/sync_call_test.abi
+++ b/tests/toolchain/abigen-pass/sync_call_test.abi
@@ -1,0 +1,93 @@
+{
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT ",
+    "version": "eosio::abi/1.3",
+    "types": [],
+    "structs": [
+        {
+            "name": "noparam",
+            "base": "",
+            "fields": []
+        },
+        {
+            "name": "sum",
+            "base": "",
+            "fields": [
+                {
+                    "name": "a",
+                    "type": "uint32"
+                },
+                {
+                    "name": "b",
+                    "type": "uint32"
+                },
+                {
+                    "name": "c",
+                    "type": "uint32"
+                }
+            ]
+        },
+        {
+            "name": "voidfunc",
+            "base": "",
+            "fields": []
+        },
+        {
+            "name": "withparam",
+            "base": "",
+            "fields": [
+                {
+                    "name": "in",
+                    "type": "uint32"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "sum",
+            "type": "sum",
+            "ricardian_contract": ""
+        }
+    ],
+    "tables": [],
+    "ricardian_clauses": [],
+    "variants": [],
+    "action_results": [
+        {
+            "name": "sum",
+            "result_type": "uint32"
+        }
+    ],
+    "calls": [
+        {
+            "name": "noparam",
+            "type": "noparam"
+        },
+        {
+            "name": "sum",
+            "type": "sum"
+        },
+        {
+            "name": "voidfunc",
+            "type": "voidfunc"
+        },
+        {
+            "name": "withparam",
+            "type": "withparam"
+        }
+    ],
+    "call_results": [
+        {
+            "name": "noparam",
+            "result_type": "uint32"
+        },
+        {
+            "name": "sum",
+            "result_type": "uint32"
+        },
+        {
+            "name": "withparam",
+            "result_type": "uint32"
+        }
+    ]
+}

--- a/tests/toolchain/abigen-pass/sync_call_test.cpp
+++ b/tests/toolchain/abigen-pass/sync_call_test.cpp
@@ -1,0 +1,27 @@
+#include <eosio/call.hpp>
+#include <eosio/eosio.hpp>
+
+class [[eosio::contract]] sync_call_test : public eosio::contract {
+public:
+   using contract::contract;
+
+   [[eosio::call]]
+   uint32_t noparam() {
+      return 10;
+   }
+   
+   [[eosio::call]]
+   uint32_t withparam(uint32_t in) {
+      return in;
+   }
+   
+   [[eosio::call]]
+   void voidfunc() {
+      int i = 10;
+   }
+   
+   [[eosio::action, eosio::call]]
+   uint32_t sum(uint32_t a, uint32_t b, uint32_t c) {
+      return a + b + c;
+   }
+};

--- a/tests/toolchain/abigen-pass/sync_call_test.json
+++ b/tests/toolchain/abigen-pass/sync_call_test.json
@@ -1,0 +1,9 @@
+{
+   "tests" : [
+      {
+         "expected" : {
+            "abi-file" : "sync_call_test.abi"
+         }
+      }
+   ]
+}

--- a/tests/toolchain/abigen-pass/tagged_number_test.json
+++ b/tests/toolchain/abigen-pass/tagged_number_test.json
@@ -1,6 +1,7 @@
 {
    "tests" : [
       {
+         "compile_flags": ["--abi-version=1.2"],
          "expected" : {
             "abi-file" : "tagged_number_test.abi"
          }

--- a/tests/toolchain/abigen-pass/using_std_array.json
+++ b/tests/toolchain/abigen-pass/using_std_array.json
@@ -1,6 +1,7 @@
 {
    "tests" : [
       {
+         "compile_flags": ["--abi-version=1.2"],
          "expected" : {
             "abi-file" : "using_std_array.abi"
          }

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -948,9 +948,13 @@ static Options CreateOptions(bool add_defaults=true) {
 
 #endif
 
+   // 1.2 -- action results
+   // 1.3 -- sync calls, bitset type, action and sync call names in C++
+   //        identifier format
+
    /* TODO add some way of defaulting these to the current highest version */
    int abi_version_major = 1;
-   int abi_version_minor = 2;
+   int abi_version_minor = 3;
 
    if (!abi_version_opt.empty()) {
       abi_version_major = std::stoi(abi_version_opt);

--- a/tools/include/eosio/abi.hpp
+++ b/tools/include/eosio/abi.hpp
@@ -30,6 +30,12 @@ struct abi_action {
    bool operator<(const abi_action& s) const { return name < s.name; }
 };
 
+struct abi_call {
+   std::string name;
+   std::string type;
+   bool operator<(const abi_call& s) const { return name < s.name; }
+};
+
 struct abi_table {
    std::string name;
    std::string type;
@@ -61,6 +67,17 @@ struct abi_action_result {
    bool operator<(const abi_action_result& ar) const { return name < ar.name; }
 };
 
+struct abi_call_result {
+   std::string name;
+   std::string type;
+   bool operator<(const abi_call_result& ar) const { return name < ar.name; }
+};
+
+// The version when sync call was first introduced.
+constexpr int abi_call_version_major = 1;
+constexpr int abi_call_version_minor = 3;
+constexpr int abi_call_version       = abi_call_version_major * 10 + abi_call_version_minor;
+
 /// From eosio libraries/chain/include/eosio/chain/abi_def.hpp
 struct abi {
    int version_major = 1;
@@ -69,11 +86,13 @@ struct abi {
    std::set<abi_struct>                   structs;
    std::set<abi_typedef>                  typedefs;
    std::set<abi_action>                   actions;
+   std::set<abi_call>                     calls;
    std::set<abi_table>                    tables;
    std::set<abi_variant>                  variants;
    std::vector<abi_ricardian_clause_pair> ricardian_clauses;
    std::vector<abi_error_message>         error_messages;
    std::set<abi_action_result>            action_results;
+   std::set<abi_call_result>              call_results;
 };
 
 inline void dump( const abi& abi ) {

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -131,6 +131,43 @@ namespace eosio { namespace cdt {
          }
       }
 
+      void add_call( const clang::CXXRecordDecl* decl ) {
+         abi_call ret;
+         auto call_name = decl->getEosioCallAttr()->getName();
+
+         if (call_name.empty()) {
+            validate_name(decl->getName().str(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); });
+            ret.name = decl->getName().str();
+         }
+         else {
+            validate_name( call_name.str(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); });
+            ret.name = call_name.str();
+         }
+         ret.type = decl->getName().str();
+         _abi.calls.insert(ret);
+      }
+
+      void add_call( const clang::CXXMethodDecl* decl ) {
+         abi_call ret;
+
+         auto call_name = decl->getEosioCallAttr()->getName();
+
+         if (call_name.empty()) {
+            validate_name( decl->getNameAsString(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
+            ret.name = decl->getNameAsString();
+         }
+         else {
+            validate_name( call_name.str(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
+            ret.name = call_name.str();
+         }
+         ret.type = decl->getNameAsString();
+         _abi.calls.insert(ret);
+         if (translate_type(decl->getReturnType()) != "void") {
+            add_type(decl->getReturnType());
+            _abi.call_results.insert({get_call_name(decl), translate_type(decl->getReturnType())});
+         }
+      }
+
       void add_tuple(const clang::QualType& type) {
          auto pt = llvm::dyn_cast<clang::ElaboratedType>(type.getTypePtr());
          auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>((pt) ? pt->desugar().getTypePtr() : type.getTypePtr());
@@ -551,6 +588,13 @@ namespace eosio { namespace cdt {
          return o;
       }
 
+      ojson call_to_json( const abi_call& a ) {
+         ojson o;
+         o["name"] = a.name;
+         o["type"] = a.type;
+         return o;
+      }
+
       ojson clause_to_json( const abi_ricardian_clause_pair& clause ) {
          ojson o;
          o["id"] = clause.id;
@@ -575,6 +619,13 @@ namespace eosio { namespace cdt {
          return o;
       }
 
+      ojson call_result_to_json( const abi_call_result& result ) {
+         ojson o;
+         o["name"] = result.name;
+         o["result_type"] = result.type;
+         return o;
+      }
+
       bool is_empty() {
          std::set<abi_table> set_of_tables;
          for ( auto t : ctables ) {
@@ -593,7 +644,7 @@ namespace eosio { namespace cdt {
             set_of_tables.insert(t);
          }
 
-         return _abi.structs.empty() && _abi.typedefs.empty() && _abi.actions.empty() && set_of_tables.empty() && _abi.ricardian_clauses.empty() && _abi.variants.empty();
+         return _abi.structs.empty() && _abi.typedefs.empty() && _abi.actions.empty() && _abi.calls.empty()  && set_of_tables.empty() && _abi.ricardian_clauses.empty() && _abi.variants.empty();
       }
 
       ojson to_json() {
@@ -658,6 +709,10 @@ namespace eosio { namespace cdt {
                if (as.name == _translate_type(a.type))
                   return true;
             }
+            for ( auto a : _abi.calls ) {
+               if (as.name == _translate_type(a.type))
+                  return true;
+            }
             for( auto t : set_of_tables ) {
                if (as.name == _translate_type(t.type))
                   return true;
@@ -667,6 +722,10 @@ namespace eosio { namespace cdt {
                   return true;
             }
             for( auto ar : _abi.action_results ) {
+               if (as.name == _translate_type(ar.type))
+                  return true;
+            }
+            for( auto ar : _abi.call_results ) {
                if (as.name == _translate_type(ar.type))
                   return true;
             }
@@ -695,6 +754,9 @@ namespace eosio { namespace cdt {
             for ( auto a : _abi.actions )
                if ( a.type == td.new_type_name )
                   return true;
+            for ( auto a : _abi.calls )
+               if ( a.type == td.new_type_name )
+                  return true;
             for ( auto _td : _abi.typedefs )
                if ( remove_suffix(_td.type) == td.new_type_name )
                   return true;
@@ -702,6 +764,9 @@ namespace eosio { namespace cdt {
                if ( ar.type == td.new_type_name )
                   return true;
             }
+            for ( auto ar : _abi.call_results )
+               if ( ar.type == td.new_type_name )
+                  return true;
             return false;
          };
 
@@ -718,6 +783,18 @@ namespace eosio { namespace cdt {
          o["actions"]     = ojson::array();
          for ( auto a : _abi.actions ) {
             o["actions"].push_back(action_to_json( a ));
+         }
+         if (_abi.version_major > abi_call_version_major ||
+             _abi.version_major == abi_call_version_major && _abi.version_minor >= abi_call_version_minor) { // sync call
+            o["calls"] = ojson::array();
+            for ( auto a : _abi.calls ) {
+               o["calls"].push_back(call_to_json( a ));
+            }
+
+            o["call_results"] = ojson::array();
+            for ( auto ar : _abi.call_results ) {
+               o["call_results"].push_back(call_result_to_json( ar ));
+            }
          }
          o["tables"]     = ojson::array();
          for ( auto t : set_of_tables ) {
@@ -778,6 +855,14 @@ namespace eosio { namespace cdt {
                   ag.add_type( param->getType() );
                }
             }
+
+            if (decl->isEosioCall() && ag.is_eosio_contract(decl, ag.get_contract_name())) {
+               ag.add_struct(decl);
+               ag.add_call(decl);
+               for (auto param : decl->parameters()) {
+                  ag.add_type( param->getType() );
+               }
+            }
             return true;
          }
          virtual bool VisitCXXRecordDecl(clang::CXXRecordDecl* decl) {
@@ -786,10 +871,12 @@ namespace eosio { namespace cdt {
                ag.add_contracts(ag.parse_contracts());
                has_added_clauses = true;
             }
-            if ((decl->isEosioAction() || decl->isEosioTable()) && ag.is_eosio_contract(decl, ag.get_contract_name())) {
+            if ((decl->isEosioAction() || decl->isEosioCall() || decl->isEosioTable()) && ag.is_eosio_contract(decl, ag.get_contract_name())) {
                ag.add_struct(decl);
                if (decl->isEosioAction())
                   ag.add_action(decl);
+               if (decl->isEosioCall())
+                  ag.add_call(decl);
                if (decl->isEosioTable())
                   ag.add_table(decl);
                for (auto field : decl->fields()) {

--- a/tools/include/eosio/abimerge.hpp
+++ b/tools/include/eosio/abimerge.hpp
@@ -37,6 +37,10 @@ class ABIMerger {
          if (std::stod(vers.substr(vers.size()-3))*10 >= 12) {
             ret["action_results"] = merge_action_results(other);
          }
+         if (std::stod(vers.substr(vers.size()-3))*10 >= abi_call_version) {
+            ret["calls"]        = merge_calls(other);
+            ret["call_results"] = merge_call_results(other);
+         }
          return ret;
       }
    private:
@@ -82,6 +86,10 @@ class ABIMerger {
                 a["type"] == b["type"];
       }
 
+      static bool call_is_same(ojson a, ojson b) {
+         return a["name"] == b["name"] &&
+                a["type"] == b["type"];
+      }
 
       static bool variant_is_same(ojson a, ojson b) {
          for (auto tya : a["types"].array_range()) {
@@ -110,6 +118,11 @@ class ABIMerger {
       }
 
       static bool action_result_is_same(ojson a, ojson b) {
+         return a["name"] == b["name"] &&
+                a["result_type"] == b["result_type"];
+      }
+
+      static bool call_result_is_same(ojson a, ojson b) {
          return a["name"] == b["name"] &&
                 a["result_type"] == b["result_type"];
       }
@@ -181,6 +194,12 @@ class ABIMerger {
          return acts;
       }
 
+      ojson merge_calls(ojson b) {
+         ojson acts = ojson::array();
+         add_object_to_array(acts, abi, b, "calls", "name", call_is_same);
+         return acts;
+      }
+
       ojson merge_tables(ojson b) {
          ojson tabs = ojson::array();
          add_object_to_array(tabs, abi, b, "tables", "name", table_is_same);
@@ -196,6 +215,12 @@ class ABIMerger {
       ojson merge_action_results(ojson b) {
          ojson res = ojson::array();
          add_object_to_array(res, abi, b, "action_results", "name", action_result_is_same);
+         return res;
+      }
+
+      ojson merge_call_results(ojson b) {
+         ojson res = ojson::array();
+         add_object_to_array(res, abi, b, "call_results", "name", call_result_is_same);
          return res;
       }
 

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -192,11 +192,16 @@ struct generation_utils {
       return decl->getNameAsString();
    }
    static inline std::string get_call_name( const clang::CXXMethodDecl* decl ) {
-      std::string call_name = "";
       auto tmp = decl->getEosioCallAttr()->getName();
       if (!tmp.empty())
          return tmp;
       return decl->getNameAsString();
+   }
+   static inline std::string get_call_name( const clang::CXXRecordDecl* decl ) {
+      auto tmp = decl->getEosioCallAttr()->getName();
+      if (!tmp.empty())
+         return tmp;
+      return decl->getName();
    }
    static inline std::string get_notify_pair( const clang::CXXMethodDecl* decl ) {
       std::string notify_pair = "";


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
* Generate `call` and `call_results` sections in ABI files for sync calls
* Bump ABI version to `1.3`
* Add test for new `call` and `call_results` sections

For the following contract

```
#include <eosio/call.hpp>
#include <eosio/eosio.hpp>

class [[eosio::contract]] sync_call_test : public eosio::contract {
public:
   using contract::contract;

   [[eosio::call]]
   uint32_t noparam() {
      return 10;
   }

   [[eosio::call]]
   uint32_t withparam(uint32_t in) {
      return in;
   }

   [[eosio::call]]
   void voidfunc() {
      int i = 10;
   }

   [[eosio::action, eosio::call]]
   uint32_t sum(uint32_t a, uint32_t b, uint32_t c) {
      return a + b + c;
   }
};

```

The ABI file is

```
{
    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT ",
    "version": "eosio::abi/1.3",
    "types": [],
    "structs": [
        {
            "name": "noparam",
            "base": "",
            "fields": []
        },
        {
            "name": "sum",
            "base": "",
            "fields": [
                {
                    "name": "a",
                    "type": "uint32"
                },
                {
                    "name": "b",
                    "type": "uint32"
                },
                {
                    "name": "c",
                    "type": "uint32"
                }
            ]
        },
        {
            "name": "voidfunc",
            "base": "",
            "fields": []
        },
        {
            "name": "withparam",
            "base": "",
            "fields": [
                {
                    "name": "in",
                    "type": "uint32"
                }
            ]
        }
    ],
    "actions": [
        {
            "name": "sum",
            "type": "sum",
            "ricardian_contract": ""
        }
    ],
    "tables": [],
    "ricardian_clauses": [],
    "variants": [],
    "action_results": [
        {
            "name": "sum",
            "result_type": "uint32"
        }
    ],
    "calls": [
        {
            "name": "noparam",
            "type": "noparam"
        },
        {
            "name": "sum",
            "type": "sum"
        },
        {
            "name": "voidfunc",
            "type": "voidfunc"
        },```

        {
            "name": "withparam",
            "type": "withparam"
        }
    ],
    "call_results": [
        {
            "name": "noparam",
            "result_type": "uint32"
        },
        {
            "name": "sum",
            "result_type": "uint32"
        },
        {
            "name": "withparam",
            "result_type": "uint32"
        }
    ]
}

```
## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
