### PR TITLE
Should not use `throw` in contracts.

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,6 @@
 {
     "antelope-spring-dev":{
-       "target":"main",
+       "target":"release/2.0",
        "prerelease":false
     }
  }

--- a/libraries/eosiolib/core/eosio/bitset.hpp
+++ b/libraries/eosiolib/core/eosio/bitset.hpp
@@ -163,7 +163,7 @@ struct bitset {
             bs.set(num_bits - i - 1); // high bitset indexes come first in the JSON representation
             break;
          default:
-            throw std::invalid_argument( "unexpected character in bitset string representation" );
+            eosio::check(false, "unexpected character in bitset string representation");
             break;
          }
       }

--- a/tests/integration/bitset_tests.cpp
+++ b/tests/integration/bitset_tests.cpp
@@ -19,8 +19,6 @@ BOOST_AUTO_TEST_SUITE(bitset_tests)
 BOOST_FIXTURE_TEST_CASE( bitset_test, tester ) try {
    create_accounts( { "test"_n } );
    produce_block();
-   // test only if `<fc/bitset>` is present (Spring 2.0+)
-#if __has_include(<fc/bitset.hpp>)
    set_code( "test"_n, contracts::simple_wasm() );
    set_abi( "test"_n, contracts::simple_abi().data() );
    produce_blocks();
@@ -28,7 +26,6 @@ BOOST_FIXTURE_TEST_CASE( bitset_test, tester ) try {
    auto  trx_trace = push_action("test"_n, "testbs"_n, "test"_n, mvo()("b", "0010"));
    auto& act_trace = trx_trace->action_traces[0];
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<fc::bitset>(act_trace.return_value), fc::bitset{"1101"});
-#endif
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/integration/bitset_tests.cpp
+++ b/tests/integration/bitset_tests.cpp
@@ -1,0 +1,31 @@
+#include <boost/test/unit_test.hpp>
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+
+#include <fc/variant_object.hpp>
+
+#include <contracts.hpp>
+
+using namespace eosio;
+using namespace eosio::testing;
+using namespace eosio::chain;
+using namespace eosio::testing;
+using namespace fc;
+
+using mvo = fc::mutable_variant_object;
+
+BOOST_AUTO_TEST_SUITE(bitset_tests)
+
+BOOST_FIXTURE_TEST_CASE( bitset_test, tester ) try {
+   create_accounts( { "test"_n } );
+   produce_block();
+   set_code( "test"_n, contracts::simple_wasm() );
+   set_abi( "test"_n, contracts::simple_abi().data() );
+   produce_blocks();
+
+   auto trx_trace = push_action("test"_n, "testbs"_n, "test"_n, mvo()("b", "0010"));
+   auto &act_trace = trx_trace->action_traces[0];
+   BOOST_REQUIRE_EQUAL(fc::raw::unpack<fc::bitset>(act_trace.return_value), fc::bitset{"1101"} );
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/integration/bitset_tests.cpp
+++ b/tests/integration/bitset_tests.cpp
@@ -23,12 +23,12 @@ BOOST_FIXTURE_TEST_CASE( bitset_test, tester ) try {
    set_abi( "test"_n, contracts::simple_abi().data() );
    produce_blocks();
 
-   // test only if fc::bitset is defined (Spring 2.0+)
-   if constexpr (std::is_class_v<fc::bitset>) {
-      auto  trx_trace = push_action("test"_n, "testbs"_n, "test"_n, mvo()("b", "0010"));
-      auto& act_trace = trx_trace->action_traces[0];
-      BOOST_REQUIRE_EQUAL(fc::raw::unpack<fc::bitset>(act_trace.return_value), fc::bitset{"1101"});
-   }
+   // test only if `<fc/bitset>` is present (Spring 2.0+)
+#if __has_include(<fc/bitset.hpp>)
+   auto  trx_trace = push_action("test"_n, "testbs"_n, "test"_n, mvo()("b", "0010"));
+   auto& act_trace = trx_trace->action_traces[0];
+   BOOST_REQUIRE_EQUAL(fc::raw::unpack<fc::bitset>(act_trace.return_value), fc::bitset{"1101"});
+#endif
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/integration/bitset_tests.cpp
+++ b/tests/integration/bitset_tests.cpp
@@ -19,12 +19,12 @@ BOOST_AUTO_TEST_SUITE(bitset_tests)
 BOOST_FIXTURE_TEST_CASE( bitset_test, tester ) try {
    create_accounts( { "test"_n } );
    produce_block();
+   // test only if `<fc/bitset>` is present (Spring 2.0+)
+#if __has_include(<fc/bitset.hpp>)
    set_code( "test"_n, contracts::simple_wasm() );
    set_abi( "test"_n, contracts::simple_abi().data() );
    produce_blocks();
 
-   // test only if `<fc/bitset>` is present (Spring 2.0+)
-#if __has_include(<fc/bitset.hpp>)
    auto  trx_trace = push_action("test"_n, "testbs"_n, "test"_n, mvo()("b", "0010"));
    auto& act_trace = trx_trace->action_traces[0];
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<fc::bitset>(act_trace.return_value), fc::bitset{"1101"});

--- a/tests/integration/bitset_tests.cpp
+++ b/tests/integration/bitset_tests.cpp
@@ -23,9 +23,12 @@ BOOST_FIXTURE_TEST_CASE( bitset_test, tester ) try {
    set_abi( "test"_n, contracts::simple_abi().data() );
    produce_blocks();
 
-   auto trx_trace = push_action("test"_n, "testbs"_n, "test"_n, mvo()("b", "0010"));
-   auto &act_trace = trx_trace->action_traces[0];
-   BOOST_REQUIRE_EQUAL(fc::raw::unpack<fc::bitset>(act_trace.return_value), fc::bitset{"1101"} );
+   // test only if fc::bitset is defined (Spring 2.0+)
+   if constexpr (std::is_class_v<fc::bitset>) {
+      auto  trx_trace = push_action("test"_n, "testbs"_n, "test"_n, mvo()("b", "0010"));
+      auto& act_trace = trx_trace->action_traces[0];
+      BOOST_REQUIRE_EQUAL(fc::raw::unpack<fc::bitset>(act_trace.return_value), fc::bitset{"1101"});
+   }
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/unit/test_contracts/simple_tests.cpp
+++ b/tests/unit/test_contracts/simple_tests.cpp
@@ -1,5 +1,6 @@
 #include <eosio/eosio.hpp>
 #include <eosio/transaction.hpp>
+#include <eosio/bitset.hpp>
 
 #include "transfer.hpp" 
 
@@ -59,6 +60,17 @@ class [[eosio::contract]] simple_tests : public contract {
          std::vector<char> data = pack(nm);
          t.actions.push_back(act);
          t.send(nm.value, get_self());
+      }
+
+      [[eosio::action]]
+      eosio::bitset testbs(eosio::bitset b) {
+         for (size_t i=0; i<b.size(); ++i) {
+            if (b[i])
+               b.clear(i);
+            else
+               b.set(i);
+         }
+         return b;
       }
 
       [[eosio::on_notify("eosio.token::transfer")]] 


### PR DESCRIPTION
I mistakingly added a `throw` in `bitset.hpp` when copying code from spring.
