### PR TITLE
SC: Support long sync call function names

### DIFF
--- a/libraries/eosiolib/contracts/eosio/call.hpp
+++ b/libraries/eosiolib/contracts/eosio/call.hpp
@@ -9,7 +9,7 @@
 #include "../../core/eosio/serialize.hpp"
 #include "../../core/eosio/datastream.hpp"
 #include "../../core/eosio/name.hpp"
-#include "../../core/eosio/identifier.hpp"
+#include "../../core/eosio/hash_id.hpp"
 
 namespace eosio {
 
@@ -88,14 +88,14 @@ namespace eosio {
     * get();
     * @endcode
     */
-   template <eosio::identifier::raw Func_Name, auto Func_Ref, access_mode Access_Mode=access_mode::read_write, support_mode Support_Mode = support_mode::abort_op>
+   template <eosio::hash_id::raw Func_Name, auto Func_Ref, access_mode Access_Mode=access_mode::read_write, support_mode Support_Mode = support_mode::abort_op>
    struct call_wrapper {
       template <typename Receiver>
       constexpr call_wrapper(Receiver&& receiver)
          : receiver(std::forward<Receiver>(receiver))
       {}
 
-      static constexpr eosio::identifier function_name = eosio::identifier(Func_Name);
+      static constexpr eosio::hash_id function_name = eosio::hash_id(Func_Name);
       eosio::name receiver {};
 
       using orig_ret_type = typename detail::function_traits<decltype(Func_Ref)>::return_type;

--- a/libraries/eosiolib/core/eosio/hash_id.hpp
+++ b/libraries/eosiolib/core/eosio/hash_id.hpp
@@ -7,18 +7,18 @@
 #include <string_view>
 
 namespace eosio {
-   struct identifier {
+   struct hash_id {
    public:
       static constexpr uint32_t max_length = 128;
 
       enum class raw : uint64_t {};
 
-      constexpr explicit identifier( identifier::raw r )
+      constexpr explicit hash_id( hash_id::raw r )
       :id(static_cast<uint64_t>(r)) {}
 
-      constexpr identifier() : id(0) {}
+      constexpr hash_id() : id(0) {}
 
-      constexpr explicit identifier( std::string_view s )
+      constexpr explicit hash_id( std::string_view s )
       : id(djbh_hash(s))
       {
          validate(s);
@@ -26,16 +26,16 @@ namespace eosio {
 
       constexpr void validate(std::string_view str) {
          if (str.empty()) {
-            eosio::check(false, "string cannot be empty to be an identifier");
+            eosio::check(false, "string cannot be empty to be an hash_id");
          }
 
          if (str.length() > max_length) {
-            eosio::check(false, "string is too long be a valid identifier. must be less than or equal to " + std::to_string(max_length));
+            eosio::check(false, "string is too long be a valid hash_id. must be less than or equal to " + std::to_string(max_length));
          }
 
          // cannot use std::isalpha in constexpr function
          if (! ((str[0] >= 'A' && str[0] <= 'Z') || (str[0] >= 'a' && str[0] <= 'z') || str[0] == '_') ) {
-            eosio::check(false, "string must start with a letter or _ to be a valid identifier.");
+            eosio::check(false, "string must start with a letter or _ to be a valid hash_id.");
          }
 
          for (char c : str.substr(1)) {
@@ -44,10 +44,6 @@ namespace eosio {
                eosio::check(false, "string contains a character " + std::string{c} + " that is not a letter, number, or _");
             }
          }
-      }
-
-      static uint64_t to_id(std::string_view s) {
-         return djbh_hash(s);
       }
 
       static constexpr uint64_t djbh_hash(std::string_view s) {
@@ -63,15 +59,15 @@ namespace eosio {
       uint64_t id = 0;
 
       CDT_REFLECT(id);
-      EOSLIB_SERIALIZE( identifier, (id) )
-   }; /// namespace identifier
+      EOSLIB_SERIALIZE( hash_id, (id) )
+   }; /// namespace hash_id
 } /// namespace eosio
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-string-literal-operator-template"
 template <typename T, T... Str>
-inline constexpr eosio::identifier operator""_i() {
-   constexpr auto x = eosio::identifier{std::string_view{eosio::detail::to_const_char_arr<Str...>::value, sizeof...(Str)}};
+inline constexpr eosio::hash_id operator""_i() {
+   constexpr auto x = eosio::hash_id{std::string_view{eosio::detail::to_const_char_arr<Str...>::value, sizeof...(Str)}};
    return x;
 }
 #pragma clang diagnostic pop

--- a/libraries/eosiolib/core/eosio/identifier.hpp
+++ b/libraries/eosiolib/core/eosio/identifier.hpp
@@ -9,7 +9,7 @@
 namespace eosio {
    struct identifier {
    public:
-      static constexpr uint32_t max_length = 32;
+      static constexpr uint32_t max_length = 128;
 
       enum class raw : uint64_t {};
 

--- a/libraries/eosiolib/core/eosio/identifier.hpp
+++ b/libraries/eosiolib/core/eosio/identifier.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "check.hpp"
+#include "serialize.hpp"
+#include "reflect.hpp"
+
+#include <string_view>
+
+namespace eosio {
+   struct identifier {
+   public:
+      static constexpr uint32_t max_length = 32;
+
+      enum class raw : uint64_t {};
+
+      constexpr explicit identifier( identifier::raw r )
+      :id(static_cast<uint64_t>(r)) {}
+
+      constexpr identifier() : id(0) {}
+
+      constexpr explicit identifier( std::string_view s )
+      : id(djbh_hash(s))
+      {
+         validate(s);
+      }
+
+      constexpr void validate(std::string_view str) {
+         if (str.empty()) {
+            eosio::check(false, "string cannot be empty to be an identifier");
+         }
+
+         if (str.length() > max_length) {
+            eosio::check(false, "string is too long be a valid identifier. must be less than or equal to " + std::to_string(max_length));
+         }
+
+         // cannot use std::isalpha in constexpr function
+         if (! ((str[0] >= 'A' && str[0] <= 'Z') || (str[0] >= 'a' && str[0] <= 'z') || str[0] == '_') ) {
+            eosio::check(false, "string must start with a letter or _ to be a valid identifier.");
+         }
+
+         for (char c : str.substr(1)) {
+            // cannot use std::isalnum in constexpr function
+            if (! ((str[0] >= 'A' && str[0] <= 'Z') || (str[0] >= 'a' && str[0] <= 'z') || (str[0] >= '0' && str[0] <= '9') || str[0] == '_') ) {
+               eosio::check(false, "string contains a character " + std::string{c} + " that is not a letter, number, or _");
+            }
+         }
+      }
+
+      static uint64_t to_id(std::string_view s) {
+         return djbh_hash(s);
+      }
+
+      static constexpr uint64_t djbh_hash(std::string_view s) {
+         uint64_t hash = 5381;
+         for (char c : s) {
+            hash = ((hash << 5) + hash) + static_cast<uint8_t>(c); // hash * 33 + c
+         }
+         return hash;
+      }
+
+      constexpr operator raw()const { return raw(id); }
+
+      uint64_t id = 0;
+
+      CDT_REFLECT(id);
+      EOSLIB_SERIALIZE( identifier, (id) )
+   }; /// namespace identifier
+} /// namespace eosio
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-string-literal-operator-template"
+template <typename T, T... Str>
+inline constexpr eosio::identifier operator""_i() {
+   constexpr auto x = eosio::identifier{std::string_view{eosio::detail::to_const_char_arr<Str...>::value, sizeof...(Str)}};
+   return x;
+}
+#pragma clang diagnostic pop

--- a/tests/toolchain/abigen-pass/sync_call_test.abi
+++ b/tests/toolchain/abigen-pass/sync_call_test.abi
@@ -82,19 +82,23 @@
     "calls": [
         {
             "name": "noparam",
-            "type": "noparam"
+            "type": "noparam",
+            "id": 229476383600947
         },
         {
             "name": "sum",
-            "type": "sum"
+            "type": "sum",
+            "id": 193506202
         },
         {
             "name": "voidfunc",
-            "type": "voidfunc"
+            "type": "voidfunc",
+            "id": 7573061335575747
         },
         {
             "name": "withparam",
-            "type": "withparam"
+            "type": "withparam",
+            "id": 249912189145794130
         }
     ],
     "call_results": [

--- a/tests/toolchain/compile-fail/sync_call_params_num_tests.cpp
+++ b/tests/toolchain/compile-fail/sync_call_params_num_tests.cpp
@@ -15,7 +15,7 @@ public:
       return a + b + c;
    }
 
-   using sum_func = eosio::call_wrapper<"sum"_n, &sync_call_invalid_arg_nums::sum>;
+   using sum_func = eosio::call_wrapper<"sum"_i, &sync_call_invalid_arg_nums::sum>;
 
    // Fewer number of arguments
    [[eosio::action]]

--- a/tests/toolchain/compile-fail/sync_call_params_type_tests.cpp
+++ b/tests/toolchain/compile-fail/sync_call_params_type_tests.cpp
@@ -14,7 +14,7 @@ public:
       return a + b + c;
    }
 
-   using sum_func = eosio::call_wrapper<"sum"_n, &sync_call_invalid_arg_nums::sum>;
+   using sum_func = eosio::call_wrapper<"sum"_i, &sync_call_invalid_arg_nums::sum>;
 
    struct empty {
    };

--- a/tests/unit/test_contracts/sync_call_addr_book_callee.hpp
+++ b/tests/unit/test_contracts/sync_call_addr_book_callee.hpp
@@ -16,9 +16,9 @@ public:
    [[eosio::call]]
    person_info get(eosio::name user);
 
-   using upsert_read_only_func = eosio::call_wrapper<"upsert"_n, &sync_call_addr_book_callee::upsert, eosio::access_mode::read_only>;
-   using upsert_func = eosio::call_wrapper<"upsert"_n, &sync_call_addr_book_callee::upsert>;
-   using get_func = eosio::call_wrapper<"get"_n, &sync_call_addr_book_callee::get>;
+   using upsert_read_only_func = eosio::call_wrapper<"upsert"_i, &sync_call_addr_book_callee::upsert, eosio::access_mode::read_only>;
+   using upsert_func = eosio::call_wrapper<"upsert"_i, &sync_call_addr_book_callee::upsert>;
+   using get_func = eosio::call_wrapper<"get"_i, &sync_call_addr_book_callee::get>;
 
 private:
    struct [[eosio::table]] person {

--- a/tests/unit/test_contracts/sync_call_callee.cpp
+++ b/tests/unit/test_contracts/sync_call_callee.cpp
@@ -2,17 +2,17 @@
 #include <eosio/print.hpp>
 
 [[eosio::call]]
-uint32_t sync_call_callee::getten() {
+uint32_t sync_call_callee::return_ten() {
    return 10;
 }
 
 [[eosio::call]]
-uint32_t sync_call_callee::getback(uint32_t in) {
+uint32_t sync_call_callee::echo_input(uint32_t in) {
    return in;
 }
 
 [[eosio::call]]
-void sync_call_callee::voidfunc() {
+void sync_call_callee::void_func() {
    eosio::print("I am a void function");
 }
 
@@ -22,12 +22,12 @@ uint32_t sync_call_callee::sum(uint32_t a, uint32_t b, uint32_t c) {
 }
 
 [[eosio::call]]
-struct1_t sync_call_callee::structonly(struct1_t s) {
+struct1_t sync_call_callee::pass_single_struct(struct1_t s) {
    return s;
 }
 
 [[eosio::call]]
-struct1_t sync_call_callee::structmix(struct1_t s1, int32_t m, struct2_t s2) {
+struct1_t sync_call_callee::pass_multi_structs(struct1_t s1, int32_t m, struct2_t s2) {
    return { .a = s1.a * m + s2.c, .b = s1.b * m + s2.d };
 }
 

--- a/tests/unit/test_contracts/sync_call_callee.hpp
+++ b/tests/unit/test_contracts/sync_call_callee.hpp
@@ -18,33 +18,33 @@ public:
    using contract::contract;
 
    [[eosio::call]]
-   uint32_t getten();
+   uint32_t return_ten();
 
    [[eosio::call]]
-   uint32_t getback(uint32_t in);
+   uint32_t echo_input(uint32_t in);
 
    [[eosio::call]]
-   void voidfunc();
+   void void_func();
 
    [[eosio::call]]
    uint32_t sum(uint32_t a, uint32_t b, uint32_t c);
 
    // pass in a struct and return it
    [[eosio::call]]
-   struct1_t structonly(struct1_t s);
+   struct1_t pass_single_struct(struct1_t s);
 
    // pass in two structs and an integer, multiply each field in the struct by
    // the integer, add last two fields of the second struct, and return the result
    [[eosio::call]]
-   struct1_t structmix(struct1_t s1, int32_t m, struct2_t s2);
+   struct1_t pass_multi_structs(struct1_t s1, int32_t m, struct2_t s2);
 
-   using getten_func = eosio::call_wrapper<"getten"_n, &sync_call_callee::getten>;
-   using getback_func = eosio::call_wrapper<"getback"_n, &sync_call_callee::getback>;
-   using voidfunc_func = eosio::call_wrapper<"voidfunc"_n, &sync_call_callee::voidfunc>;
-   using sum_func = eosio::call_wrapper<"sum"_n, &sync_call_callee::sum>;
-   using structonly_func = eosio::call_wrapper<"structonly"_n, &sync_call_callee::structonly>;
-   using structmix_func = eosio::call_wrapper<"structmix"_n, &sync_call_callee::structmix>;
+   using return_ten_func = eosio::call_wrapper<"return_ten"_i, &sync_call_callee::return_ten>;
+   using echo_input_func = eosio::call_wrapper<"echo_input"_i, &sync_call_callee::echo_input>;
+   using void_func_func = eosio::call_wrapper<"void_func"_i, &sync_call_callee::void_func>;
+   using sum_func = eosio::call_wrapper<"sum"_i, &sync_call_callee::sum>;
+   using pass_single_struct_func = eosio::call_wrapper<"pass_single_struct"_i, &sync_call_callee::pass_single_struct>;
+   using pass_multi_structs_func = eosio::call_wrapper<"pass_multi_structs"_i, &sync_call_callee::pass_multi_structs>;
 
-   using void_no_op_success_func = eosio::call_wrapper<"voidfunc"_n, &sync_call_callee::voidfunc, eosio::access_mode::read_write, eosio::support_mode::no_op>;
-   using sum_no_op_success_func = eosio::call_wrapper<"sum"_n, &sync_call_callee::sum, eosio::access_mode::read_write, eosio::support_mode::no_op>;
+   using void_no_op_success_func = eosio::call_wrapper<"void_func"_i, &sync_call_callee::void_func, eosio::access_mode::read_write, eosio::support_mode::no_op>;
+   using sum_no_op_success_func = eosio::call_wrapper<"sum"_i, &sync_call_callee::sum, eosio::access_mode::read_write, eosio::support_mode::no_op>;
 };

--- a/tests/unit/test_contracts/sync_call_caller.cpp
+++ b/tests/unit/test_contracts/sync_call_caller.cpp
@@ -13,7 +13,7 @@ public:
    // Using host function directly
    [[eosio::action]]
    void hstretvaltst() {
-      call_data_header header{ .version = 0, .func_name = "getten"_n.value };
+      call_data_header header{ .version = 0, .func_name = "return_ten"_i.id };
       const std::vector<char> data{ eosio::pack(header) };
       auto expected_size = eosio::call("callee"_n, 0, data.data(), data.size());
       eosio::check(expected_size >= 0, "call did not return a positive value");
@@ -22,21 +22,21 @@ public:
       return_value.resize(expected_size);
       auto actual_size = eosio::get_call_return_value(return_value.data(), return_value.size());
       eosio::check(actual_size == expected_size, "actual_size not equal to expected_size");
-      eosio::check(eosio::unpack<uint32_t>(return_value) == 10u, "return value not 10");  // getten always returns 10
+      eosio::check(eosio::unpack<uint32_t>(return_value) == 10u, "return value not 10");  // return_ten always returns 10
    }
 
    // Using call_wrapper
    [[eosio::action]]
    void wrpretvaltst() {
-      sync_call_callee::getten_func getten{ "callee"_n };
-      eosio::check(getten() == 10u, "return value not 10");
+      sync_call_callee::return_ten_func return_ten{ "callee"_n };
+      eosio::check(return_ten() == 10u, "return value not 10");
    }
 
    // Using host function directly, testing one parameter passing
    [[eosio::action]]
    void hstoneprmtst() {
-      // `getback(uint32_t p)` returns p
-      call_data_header header{ .version = 0, .func_name = "getback"_n.value };
+      // `echo_input(uint32_t p)` returns p
+      call_data_header header{ .version = 0, .func_name = "echo_input"_i.id };
       const std::vector<char> data{ eosio::pack(std::make_tuple(header, 5)) };
       auto expected_size = eosio::call("callee"_n, 0, data.data(), data.size());
       eosio::check(expected_size >= 0, "call did not return a positive value");
@@ -45,20 +45,20 @@ public:
       return_value.resize(expected_size);
       auto actual_size = eosio::get_call_return_value(return_value.data(), return_value.size());
       eosio::check(actual_size == expected_size, "actual_size not equal to expected_size");
-      eosio::check(eosio::unpack<uint32_t>(return_value) == 5u, "return value not 5");  // getback returns back the same value of parameter
+      eosio::check(eosio::unpack<uint32_t>(return_value) == 5u, "return value not 5");  // echo_input returns back the same value of parameter
    }
 
    // Using call_wrapper, testing one parameter passing
    [[eosio::action]]
    void wrponeprmtst() {
-      sync_call_callee::getback_func getback{ "callee"_n };
-      eosio::check(getback(5) == 5u, "return value not 5");
+      sync_call_callee::echo_input_func echo_input{ "callee"_n };
+      eosio::check(echo_input(5) == 5u, "return value not 5");
    }
 
    // Using host function directly, testing multiple parameters passing
    [[eosio::action]]
    void hstmulprmtst() {
-      call_data_header header{ .version = 0, .func_name = "sum"_n.value };
+      call_data_header header{ .version = 0, .func_name = "sum"_i.id };
       const std::vector<char> data{ eosio::pack(std::make_tuple(header, 10, 20, 30)) };
       auto expected_size = eosio::call("callee"_n, 0, data.data(), data.size());
       eosio::check(expected_size >= 0, "call did not return a positive value");
@@ -80,9 +80,9 @@ public:
    // Verify single struct parameter passing
    [[eosio::action]]
    void structtest() {
-      sync_call_callee::structonly_func func{ "callee"_n };
+      sync_call_callee::pass_single_struct_func func{ "callee"_n };
       struct1_t input = { 10, 20 };
-      auto output = func(input); // structonly_func returns the input as is
+      auto output = func(input); // pass_single_struct_func returns the input as is
       eosio::check(output.a == input.a, "field a in output is not equal to a in input");
       eosio::check(output.b == input.b, "field b in output is not equal to b in input");
    }
@@ -90,12 +90,12 @@ public:
    // Verify mix of struct and integer parameters passing
    [[eosio::action]]
    void structinttst() {
-      sync_call_callee::structmix_func func{ "callee"_n };
+      sync_call_callee::pass_multi_structs_func func{ "callee"_n };
       struct1_t input1 = { 10, 20 };
       struct2_t input2 = { 'a', true, 50, 100 };
       int32_t m = 2;
 
-      // structmix_func multiply each field of input1 by m,
+      // pass_multi_structs_func multiply each field of input1 by m,
       // add last two fields of input2, and return a struct1_t
       auto output = func(input1, m, input2);
       eosio::check(output.a == m * input1.a + input2.c, "field a of output is not correct");
@@ -104,7 +104,7 @@ public:
 
    [[eosio::action]]
    void hstvodfuntst() {
-      call_data_header header{ .version = 0, .func_name = "voidfunc"_n.value };
+      call_data_header header{ .version = 0, .func_name = "void_func"_i.id };
       const std::vector<char> data{ eosio::pack(header) };
       auto expected_size = eosio::call("callee"_n, 0, data.data(), data.size());
       eosio::check(expected_size == 0, "call did not return 0"); // void function. return value size should be 0
@@ -112,8 +112,8 @@ public:
 
    [[eosio::action]]
    void wrpvodfuntst() {
-      sync_call_callee::voidfunc_func voidfunc{ "callee"_n };
-      voidfunc();
+      sync_call_callee::void_func_func void_func{ "callee"_n };
+      void_func();
    }
 
    // Verify void call. void_func uses default support_mode::abort
@@ -127,7 +127,7 @@ public:
    [[eosio::action]]
    void voidfncnoop() {
       sync_call_not_supported::void_no_op_func void_func_no_op{ "callee"_n };
-      check(void_func_no_op() == std::nullopt, "void_func_no_op did not return std::nullopt");
+      check(void_func_no_op() == std::nullopt, "void_func_io_op did not return std::nullopt");
    }
 
    // verify non-void call. int_func uses default support_mode::abort
@@ -141,33 +141,33 @@ public:
    [[eosio::action]]
    void intfuncnoop() {
       sync_call_not_supported::int_no_op_func int_func_no_op{ "callee"_n };
-      check(int_func_no_op() == std::nullopt, "void_func_no_op did not return std::nullopt");
+      check(int_func_no_op() == std::nullopt, "void_func_io_op did not return std::nullopt");
    }
 
-   // void_no_op_success_func uses support_mode::no_op
+   // void_io_op_success_func uses support_mode::no_op
    [[eosio::action]]
    void voidnoopsucc() {
       sync_call_callee::void_no_op_success_func f{ "callee"_n };
-      check(f().has_value(), "void_no_op_success_func did not return a value");
+      check(f().has_value(), "void_io_op_success_func did not return a value");
    }
 
-   // void_no_op_success_func uses support_mode::no_op
+   // void_io_op_success_func uses support_mode::no_op
    [[eosio::action]]
    void sumnoopsucc() {
       sync_call_callee::sum_no_op_success_func f{ "callee"_n };
-      check(*f(7, 8, 9) == 24, "sum_no_op_success_func did not return a value");
+      check(*f(7, 8, 9) == 24, "sum_io_op_success_func did not return a value");
    }
 
    [[eosio::action]]
    void hdrvaltest() {
       // Verify function name validation works
-      call_data_header unkwn_func_header{ .version = 0, .func_name = "unknwnfunc"_n.value };
-      const std::vector<char> unkwn_func_data{ eosio::pack(unkwn_func_header) }; // unknwnfunc is not in "callee"_n contract
+      call_data_header unkwn_func_header{ .version = 0, .func_name = "unknwnfunc"_i.id };
+      const std::vector<char> unkwn_func_data{ eosio::pack(unkwn_func_header) }; // unknwnfunc is not in "callee"_i contract
       auto status = eosio::call("callee"_n, 0, unkwn_func_data.data(), unkwn_func_data.size());
       eosio::check(status == -10001, "call did not return -10001 for unknown function");
 
       // Verify version validation works
-      call_data_header bad_version_header{ .version = 1, .func_name = "sum"_n.value };  // version 1 is not supported
+      call_data_header bad_version_header{ .version = 1, .func_name = "sum"_i.id };  // version 1 is not supported
       const std::vector<char> bad_version_data{ eosio::pack(bad_version_header) };
       status = eosio::call("callee"_n, 0, bad_version_data.data(), bad_version_data.size());
       eosio::check(status == -10000, "call did not return -10000 for invalid version");

--- a/tests/unit/test_contracts/sync_call_not_supported.hpp
+++ b/tests/unit/test_contracts/sync_call_not_supported.hpp
@@ -15,9 +15,9 @@ public:
    [[eosio::action]]
    int intfunc();
 
-   using void_func = eosio::call_wrapper<"voidfunc"_n, &sync_call_not_supported::voidfunc>;  // default behavior: abort when called
-   using void_no_op_func = eosio::call_wrapper<"voidfunc"_n, &sync_call_not_supported::voidfunc, eosio::access_mode::read_write, eosio::support_mode::no_op>; // no op when called
+   using void_func = eosio::call_wrapper<"voidfunc"_i, &sync_call_not_supported::voidfunc>;  // default behavior: abort when called
+   using void_no_op_func = eosio::call_wrapper<"voidfunc"_i, &sync_call_not_supported::voidfunc, eosio::access_mode::read_write, eosio::support_mode::no_op>; // no op when called
    
-   using int_func = eosio::call_wrapper<"intfunc"_n, &sync_call_not_supported::intfunc>;  // default behavior: abort when called
-   using int_no_op_func = eosio::call_wrapper<"intfunc"_n, &sync_call_not_supported::intfunc, eosio::access_mode::read_write, eosio::support_mode::no_op>; // no op when called
+   using int_func = eosio::call_wrapper<"intfunc"_i, &sync_call_not_supported::intfunc>;  // default behavior: abort when called
+   using int_no_op_func = eosio::call_wrapper<"intfunc"_i, &sync_call_not_supported::intfunc, eosio::access_mode::read_write, eosio::support_mode::no_op>; // no op when called
 };

--- a/tests/unit/test_contracts/sync_call_single_func.cpp
+++ b/tests/unit/test_contracts/sync_call_single_func.cpp
@@ -7,7 +7,7 @@ public:
    using contract::contract;
 
    [[eosio::call]]
-   uint32_t getten() {
+   uint32_t return_ten() {
       return 10;
    }
 

--- a/tools/include/eosio/abi.hpp
+++ b/tools/include/eosio/abi.hpp
@@ -33,6 +33,7 @@ struct abi_action {
 struct abi_call {
    std::string name;
    std::string type;
+   uint64_t    id = 0;  // internal short ID of `name`
    bool operator<(const abi_call& s) const { return name < s.name; }
 };
 

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -144,7 +144,7 @@ namespace eosio { namespace cdt {
             ret.name = call_name.str();
          }
          ret.type = decl->getName().str();
-         ret.id = identifier_to_id(ret.name);
+         ret.id = to_hash_id(ret.name);
          _abi.calls.insert(ret);
       }
 
@@ -154,15 +154,15 @@ namespace eosio { namespace cdt {
          auto call_name = decl->getEosioCallAttr()->getName();
 
          if (call_name.empty()) {
-            validate_identifier( decl->getNameAsString(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
+            validate_hash_id( decl->getNameAsString(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
             ret.name = decl->getNameAsString();
          }
          else {
-            validate_identifier( call_name.str(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
+            validate_hash_id( call_name.str(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
             ret.name = call_name.str();
          }
          ret.type = decl->getNameAsString();
-         ret.id = identifier_to_id(ret.name);
+         ret.id = to_hash_id(ret.name);
          _abi.calls.insert(ret);
          if (translate_type(decl->getReturnType()) != "void") {
             add_type(decl->getReturnType());

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -153,11 +153,11 @@ namespace eosio { namespace cdt {
          auto call_name = decl->getEosioCallAttr()->getName();
 
          if (call_name.empty()) {
-            validate_name( decl->getNameAsString(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
+            validate_identifier( decl->getNameAsString(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
             ret.name = decl->getNameAsString();
          }
          else {
-            validate_name( call_name.str(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
+            validate_identifier( call_name.str(), [&](auto s) { CDT_ERROR("abigen_error", decl->getLocation(), s); } );
             ret.name = call_name.str();
          }
          ret.type = decl->getNameAsString();

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -144,6 +144,7 @@ namespace eosio { namespace cdt {
             ret.name = call_name.str();
          }
          ret.type = decl->getName().str();
+         ret.id = identifier_to_id(ret.name);
          _abi.calls.insert(ret);
       }
 
@@ -161,6 +162,7 @@ namespace eosio { namespace cdt {
             ret.name = call_name.str();
          }
          ret.type = decl->getNameAsString();
+         ret.id = identifier_to_id(ret.name);
          _abi.calls.insert(ret);
          if (translate_type(decl->getReturnType()) != "void") {
             add_type(decl->getReturnType());
@@ -607,6 +609,7 @@ namespace eosio { namespace cdt {
          ojson o;
          o["name"] = c.name;
          o["type"] = c.type;
+         o["id"]   = c.id;
          return o;
       }
 

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -369,10 +369,25 @@ namespace eosio { namespace cdt {
                   cg.notify_handlers.insert(full_notify_name); // insert the method action, so we don't create the dispatcher twice
                }
             } else if (decl->isEosioCall()) {
+               static std::unordered_map<uint64_t, std::string> _call_id_map;
+
                name = generation_utils::get_call_name(decl);
-               validate_name(name, [&](auto s) {
-                  CDT_ERROR("codegen_error", decl->getLocation(), std::string("call name (")+s+") is not a valid eosio name");
+               validate_identifier(name, [&](auto s) {
+                  CDT_ERROR("codegen_error", decl->getLocation(), std::string("call name (")+s+") is not a valid C++ identifier");
                });
+
+               // Make sure there are no conflicts of IDs
+               auto id = identifier_to_id(name);
+               auto it = _call_id_map.find(id);
+               if (it != _call_id_map.end()) {
+                  if (name != it->second) {
+                     CDT_ERROR("codegen_error",
+                               decl->getLocation(),
+                               std::string("call name (") + name + ")'s ID " + std::to_string(id) +  "  conflicts with a previous call name: " + it->second + ". Please choose another name");
+                  }
+               } else {
+                  _call_id_map.insert({id, name});
+               }
 
                // Genereate create_get_sync_call_data and create_get_sync_call_data_header only once
                if (_call_set.empty()) {

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -372,12 +372,12 @@ namespace eosio { namespace cdt {
                static std::unordered_map<uint64_t, std::string> _call_id_map;
 
                name = generation_utils::get_call_name(decl);
-               validate_identifier(name, [&](auto s) {
+               validate_hash_id(name, [&](auto s) {
                   CDT_ERROR("codegen_error", decl->getLocation(), std::string("call name (")+s+") is not a valid C++ identifier");
                });
 
                // Make sure there are no conflicts of IDs
-               auto id = identifier_to_id(name);
+               auto id = to_hash_id(name);
                auto it = _call_id_map.find(id);
                if (it != _call_id_map.end()) {
                   if (name != it->second) {

--- a/tools/include/eosio/utils.hpp
+++ b/tools/include/eosio/utils.hpp
@@ -97,32 +97,32 @@ std::string name_to_string( uint64_t nm ) {
    return str;
 }
 
-static constexpr uint32_t max_identifier_length = 128;
+static constexpr uint32_t max_string_length_for_hash_id = 128;
 
 // Validate the input `str` is a valid C/C++ identifier
 template <typename Lambda>
-void validate_identifier( const std::string& str, Lambda&& error_handler ) {
+void validate_hash_id( const std::string& str, Lambda&& error_handler ) {
    if (str.empty()) {
-      return error_handler("identifier is empty");
+      return error_handler("string is empty");
    }
 
    const auto len = str.length();
-   if ( len > max_identifier_length ) {
-      return error_handler(std::string("identifier {") + str + "} is more than " + std::to_string(max_identifier_length) + " characters long");
+   if ( len > max_string_length_for_hash_id ) {
+      return error_handler(std::string("string {") + str + "} is more than " + std::to_string(max_string_length_for_hash_id) + " characters long");
    }
 
    if (!(std::isalpha(str[0]) || str[0] == '_')) {
-      return error_handler(std::string("identifier {") + str + "} does not start with letter or underscore");
+      return error_handler(std::string("string {") + str + "} does not start with letter or underscore");
    }
 
    for (char ch : str.substr(1)) {
       if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) {
-         return error_handler(std::string("identifier {") + str + "} has a character {" + ch +  "} which is not a number, letter, or _");
+         return error_handler(std::string("string {") + str + "} has a character {" + ch +  "} which is not a number, letter, or _");
       }
    }
 }
 
-uint64_t identifier_to_id(std::string str) {
+uint64_t to_hash_id(std::string str) {
    uint64_t hash = 5381;
    for (char c : str) {
       hash = ((hash << 5) + hash) + static_cast<uint8_t>(c); // hash * 33 + c

--- a/tools/include/eosio/utils.hpp
+++ b/tools/include/eosio/utils.hpp
@@ -97,7 +97,7 @@ std::string name_to_string( uint64_t nm ) {
    return str;
 }
 
-static constexpr uint32_t max_identifier_length = 32;
+static constexpr uint32_t max_identifier_length = 128;
 
 // Validate the input `str` is a valid C/C++ identifier
 template <typename Lambda>

--- a/tools/include/eosio/utils.hpp
+++ b/tools/include/eosio/utils.hpp
@@ -97,6 +97,39 @@ std::string name_to_string( uint64_t nm ) {
    return str;
 }
 
+static constexpr uint32_t max_identifier_length = 32;
+
+// Validate the input `str` is a valid C/C++ identifier
+template <typename Lambda>
+void validate_identifier( const std::string& str, Lambda&& error_handler ) {
+   if (str.empty()) {
+      return error_handler("identifier is empty");
+   }
+
+   const auto len = str.length();
+   if ( len > max_identifier_length ) {
+      return error_handler(std::string("identifier {") + str + "} is more than " + std::to_string(max_identifier_length) + " characters long");
+   }
+
+   if (!(std::isalpha(str[0]) || str[0] == '_')) {
+      return error_handler(std::string("identifier {") + str + "} does not start with letter or underscore");
+   }
+
+   for (char ch : str.substr(1)) {
+      if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_')) {
+         return error_handler(std::string("identifier {") + str + "} has a character {" + ch +  "} which is not a number, letter, or _");
+      }
+   }
+}
+
+uint64_t identifier_to_id(std::string str) {
+   uint64_t hash = 5381;
+   for (char c : str) {
+      hash = ((hash << 5) + hash) + static_cast<uint8_t>(c); // hash * 33 + c
+   }
+   return hash;
+}
+
 struct environment {
    static llvm::ArrayRef<llvm::StringRef> get() {
       static std::vector<llvm::StringRef> env_table;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Work in progress:

This PR adds support of long sync call function names. Now a sync call function name can be any valid C++ identifier with max length of 128 characters. This provides much flexibilities in choosing sync call function names than using `eosio::name`.

Please note, this is a quick implementation for dev-preview-1. Internal implementation might be changed in dev-preview-2 but user-faced interface should keep the same.

Resolves https://github.com/AntelopeIO/cdt/issues/361

The following is a working example of using C++ identifiers for sync call function names.

```
#include <eosio/call.hpp>
#include <eosio/eosio.hpp>

struct struct1_t {
   int64_t a;
   uint64_t b;
};

struct struct2_t {
   char a;
   bool b;
   int64_t c;
   uint64_t d;
};

class [[eosio::contract]] sync_call_callee : public eosio::contract{
public:
   using contract::contract;

   [[eosio::call]]
   uint32_t return_ten();

   [[eosio::call]]
   uint32_t echo_input(uint32_t in);

   [[eosio::call]]
   void void_func();

   [[eosio::call]]
   uint32_t sum(uint32_t a, uint32_t b, uint32_t c);

   // pass in a struct and return it
   [[eosio::call]]
   struct1_t pass_single_struct(struct1_t s);

   // pass in two structs and an integer, multiply each field in the struct by
   // the integer, add last two fields of the second struct, and return the result
   [[eosio::call]]
   struct1_t pass_multi_structs(struct1_t s1, int32_t m, struct2_t s2);

   using return_ten_func = eosio::call_wrapper<"return_ten"_i, &sync_call_callee::return_ten>;
   using echo_input_func = eosio::call_wrapper<"echo_input"_i, &sync_call_callee::echo_input>;
   using void_func_func = eosio::call_wrapper<"void_func"_i, &sync_call_callee::void_func>;
   using sum_func = eosio::call_wrapper<"sum"_i, &sync_call_callee::sum>;
   using pass_single_struct_func = eosio::call_wrapper<"pass_single_struct"_i, &sync_call_callee::pass_single_struct>;
   using pass_multi_structs_func = eosio::call_wrapper<"pass_multi_structs"_i, &sync_call_callee::pass_multi_structs>;

   using void_no_op_success_func = eosio::call_wrapper<"void_func"_i, &sync_call_callee::void_func, eosio::access_mode::read_write, eosio::support_mode::no_op>;
   using sum_no_op_success_func = eosio::call_wrapper<"sum"_i, &sync_call_callee::sum, eosio::access_mode::read_write, eosio::support_mode::no_op>;
};

```

ABI for sync calls looks like

```
    "calls": [
        {
            "name": "echo_input",
            "type": "echo_input",
            "id": 8246257893603280403
        },
        {
            "name": "pass_multi_structs",
            "type": "pass_multi_structs",
            "id": 6647878943616557085
        },
...

```
## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
