### PR TITLE
[5.0.0-dev] Add `is_sync_call()` to `eosio::contract` class

### DIFF
--- a/libraries/eosiolib/contracts/eosio/contract.hpp
+++ b/libraries/eosiolib/contracts/eosio/contract.hpp
@@ -31,7 +31,8 @@ class contract {
    public:
       enum class exec_type_t : uint8_t {
          action,
-         call
+         call,
+         unknown
       };
 
       /**
@@ -86,8 +87,8 @@ class contract {
        * @return bool - Whether this contract is for a sync call
        */
       inline bool is_sync_call()const {
-         check(_exec_type.has_value(), "too early to call is_sync_call(). _exec_type has not been set yet");
-         return (*_exec_type == exec_type_t::call);
+         check(_exec_type != exec_type_t::unknown, "too early to call is_sync_call(). _exec_type has not been set yet");
+         return (_exec_type == exec_type_t::call);
       }
 
       /**
@@ -119,6 +120,6 @@ class contract {
       /**
        * The execution type: action or sync call
        */
-      std::optional<exec_type_t> _exec_type = std::nullopt; // use std::optional to prevent from being used before having value like in constructors
+      exec_type_t _exec_type = exec_type_t::unknown;
 };
 }

--- a/libraries/eosiolib/contracts/eosio/contract.hpp
+++ b/libraries/eosiolib/contracts/eosio/contract.hpp
@@ -35,8 +35,9 @@ class contract {
        * @param self - The name of the account this contract is deployed on
        * @param first_receiver - The account the incoming action was first received at.
        * @param ds - The datastream used
+       * @param is_call - This contract is created for a sync call
        */
-      contract( name self, name first_receiver, datastream<const char*> ds ):_self(self),_first_receiver(first_receiver),_ds(ds) {}
+      contract( name self, name first_receiver, datastream<const char*> ds, bool is_call = false ):_self(self),_first_receiver(first_receiver),_ds(ds),_is_call(is_call) {}
 
       /**
        *
@@ -75,6 +76,13 @@ class contract {
        */
       inline const datastream<const char*>& get_datastream()const { return _ds; }
 
+      /**
+       * Whether this contract is created for a sync call
+       *
+       * @return bool - Whether this contract is created for a sync call
+       */
+      inline bool is_sync_call()const { return _is_call; }
+
    protected:
       /**
        * The name of the account this contract is deployed on.
@@ -90,5 +98,10 @@ class contract {
        * The datastream for this contract
        */
       datastream<const char*> _ds = datastream<const char*>(nullptr, 0);
+
+      /**
+       * The indication whether the contract is created for sync call or not
+       */
+      bool _is_call = false;
 };
 }

--- a/tests/toolchain/build-pass/separate_cpp_hpp.hpp
+++ b/tests/toolchain/build-pass/separate_cpp_hpp.hpp
@@ -1,6 +1,6 @@
 #include <eosio/eosio.hpp>
 
-class [[eosio::contract]] separate_cpp_hpp : public eosio::contract {
+class [[eosio::contract]] separate_cpp_hpp : eosio::contract {
 public:
    using contract::contract;
 

--- a/tests/toolchain/build-pass/separate_cpp_hpp.hpp
+++ b/tests/toolchain/build-pass/separate_cpp_hpp.hpp
@@ -1,6 +1,6 @@
 #include <eosio/eosio.hpp>
 
-class [[eosio::contract]] separate_cpp_hpp : eosio::contract {
+class [[eosio::contract]] separate_cpp_hpp : public eosio::contract {
 public:
    using contract::contract;
 

--- a/tests/unit/test_contracts/sync_call_addr_book_callee.hpp
+++ b/tests/unit/test_contracts/sync_call_addr_book_callee.hpp
@@ -8,7 +8,7 @@ struct person_info {
 
 class [[eosio::contract]] sync_call_addr_book_callee : public eosio::contract {
 public:
-   sync_call_addr_book_callee(eosio::name receiver, eosio::name code, eosio::datastream<const char*> ds): contract(receiver, code, ds) {}
+   sync_call_addr_book_callee(eosio::name receiver, eosio::name code, eosio::datastream<const char*> ds, bool is_call = false): contract(receiver, code, ds, is_call) {}
 
    [[eosio::call]]
    void upsert(eosio::name user, std::string first_name, std::string street);

--- a/tests/unit/test_contracts/sync_call_addr_book_callee.hpp
+++ b/tests/unit/test_contracts/sync_call_addr_book_callee.hpp
@@ -8,7 +8,7 @@ struct person_info {
 
 class [[eosio::contract]] sync_call_addr_book_callee : public eosio::contract {
 public:
-   sync_call_addr_book_callee(eosio::name receiver, eosio::name code, eosio::datastream<const char*> ds, bool is_call = false): contract(receiver, code, ds, is_call) {}
+   sync_call_addr_book_callee(eosio::name receiver, eosio::name code, eosio::datastream<const char*> ds): contract(receiver, code, ds) {}
 
    [[eosio::call]]
    void upsert(eosio::name user, std::string first_name, std::string street);

--- a/tests/unit/test_contracts/sync_call_callee.cpp
+++ b/tests/unit/test_contracts/sync_call_callee.cpp
@@ -31,3 +31,6 @@ struct1_t sync_call_callee::pass_multi_structs(struct1_t s1, int32_t m, struct2_
    return { .a = s1.a * m + s2.c, .b = s1.b * m + s2.d };
 }
 
+bool sync_call_callee::issynccall() {
+   return is_sync_call();
+}

--- a/tests/unit/test_contracts/sync_call_callee.hpp
+++ b/tests/unit/test_contracts/sync_call_callee.hpp
@@ -38,6 +38,11 @@ public:
    [[eosio::call]]
    struct1_t pass_multi_structs(struct1_t s1, int32_t m, struct2_t s2);
 
+   // return is_sync_call()
+   [[eosio::action, eosio::call]]
+   bool issynccall();
+   using issynccall_func = eosio::call_wrapper<"issynccall"_i, &sync_call_callee::issynccall>;
+
    using return_ten_func = eosio::call_wrapper<"return_ten"_i, &sync_call_callee::return_ten>;
    using echo_input_func = eosio::call_wrapper<"echo_input"_i, &sync_call_callee::echo_input>;
    using void_func_func = eosio::call_wrapper<"void_func"_i, &sync_call_callee::void_func>;

--- a/tests/unit/test_contracts/sync_call_caller.cpp
+++ b/tests/unit/test_contracts/sync_call_caller.cpp
@@ -172,4 +172,11 @@ public:
       status = eosio::call("callee"_n, 0, bad_version_data.data(), bad_version_data.size());
       eosio::check(status == -10000, "call did not return -10000 for invalid version");
    }
+
+   // Call issynccall as a sync call and return its return value
+   [[eosio::action]]
+   bool makesynccall() {
+      sync_call_callee::issynccall_func is_sync_call_func{ "callee"_n };
+      return is_sync_call_func();
+   }
 };

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -218,7 +218,8 @@ namespace eosio { namespace cdt {
                // it may not have `set_exec_type()`. We need to make sure the class derives
                // from `eosio::contract` before calling set_exec_type().
                if (base_is_eosio_contract_class(decl)) {
-                  ss << "obj.set_exec_type(eosio::contract::exec_type_t::action);\n";
+                  // static_cast is for cases when a contract derives from `eosio::contract` privately
+                  ss << "static_cast<eosio::contract&>obj.set_exec_type(eosio::contract::exec_type_t::action);\n";
                }
 
                const auto& call_action = [&]() {
@@ -302,7 +303,8 @@ namespace eosio { namespace cdt {
                // it may not have `set_exec_type()`. We need to make sure the class derives
                // from `eosio::contract` before calling set_exec_type().
                if (base_is_eosio_contract_class(decl)) {
-                  ss << "obj.set_exec_type(eosio::contract::exec_type_t::call);\n";
+                  // static_cast is for cases when a contract derives from `eosio::contract` privately
+                  ss << "static_cast<eosio::contract&>obj.set_exec_type(eosio::contract::exec_type_t::call);\n";
                }
 
                const auto& call_function = [&]() {

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -261,7 +261,8 @@ namespace eosio { namespace cdt {
                   i++;
                }
                const auto& call_function = [&]() {
-                  ss << decl->getParent()->getQualifiedNameAsString() << "{eosio::name{receiver},eosio::name{receiver},ds}." << decl->getNameAsString() << "(";
+                  // `true` indicates a sync call
+                  ss << decl->getParent()->getQualifiedNameAsString() << "{eosio::name{receiver},eosio::name{receiver},ds,true}." << decl->getNameAsString() << "(";
                   for (int i=0; i < decl->parameters().size(); i++) {
                      ss << "arg" << i;
                      if (i < decl->parameters().size()-1)

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -218,8 +218,7 @@ namespace eosio { namespace cdt {
                // it may not have `set_exec_type()`. We need to make sure the class derives
                // from `eosio::contract` before calling set_exec_type().
                if (base_is_eosio_contract_class(decl)) {
-                  // static_cast is for cases when a contract derives from `eosio::contract` privately
-                  ss << "static_cast<eosio::contract&>(obj).set_exec_type(eosio::contract::exec_type_t::action);\n";
+                  ss << "obj.set_exec_type(eosio::contract::exec_type_t::action);\n";
                }
 
                const auto& call_action = [&]() {
@@ -303,8 +302,7 @@ namespace eosio { namespace cdt {
                // it may not have `set_exec_type()`. We need to make sure the class derives
                // from `eosio::contract` before calling set_exec_type().
                if (base_is_eosio_contract_class(decl)) {
-                  // static_cast is for cases when a contract derives from `eosio::contract` privately
-                  ss << "static_cast<eosio::contract&>(obj).set_exec_type(eosio::contract::exec_type_t::call);\n";
+                  ss << "obj.set_exec_type(eosio::contract::exec_type_t::call);\n";
                }
 
                const auto& call_function = [&]() {

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -219,7 +219,7 @@ namespace eosio { namespace cdt {
                // from `eosio::contract` before calling set_exec_type().
                if (base_is_eosio_contract_class(decl)) {
                   // static_cast is for cases when a contract derives from `eosio::contract` privately
-                  ss << "static_cast<eosio::contract&>obj.set_exec_type(eosio::contract::exec_type_t::action);\n";
+                  ss << "static_cast<eosio::contract&>(obj).set_exec_type(eosio::contract::exec_type_t::action);\n";
                }
 
                const auto& call_action = [&]() {
@@ -304,7 +304,7 @@ namespace eosio { namespace cdt {
                // from `eosio::contract` before calling set_exec_type().
                if (base_is_eosio_contract_class(decl)) {
                   // static_cast is for cases when a contract derives from `eosio::contract` privately
-                  ss << "static_cast<eosio::contract&>obj.set_exec_type(eosio::contract::exec_type_t::call);\n";
+                  ss << "static_cast<eosio::contract&>(obj).set_exec_type(eosio::contract::exec_type_t::call);\n";
                }
 
                const auto& call_function = [&]() {

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -146,11 +146,28 @@ namespace eosio { namespace cdt {
             return "";
          }
 
+         // Return `true` if the method `decl`'s base class if `eosio::contract`
+         bool base_is_eosio_contract_class(const clang::CXXMethodDecl* decl) {
+            auto cxx_decl = decl->getParent();
+            // on this point it could be just an attribute so let's check base classes
+            for (const auto& base : cxx_decl->bases()) {
+               if (const clang::Type *base_type = base.getType().getTypePtrOrNull()) {
+                  if (const auto* cur_cxx_decl = base_type->getAsCXXRecordDecl()) {
+                     if (cur_cxx_decl->getQualifiedNameAsString() == "eosio::contract") {
+                        return true;;
+                     }
+                  }
+               }
+            }
+            return false;
+         }
+
          template <typename F>
          void create_dispatch(const std::string& attr, const std::string& func_name, F&& get_str, CXXMethodDecl* decl) {
             constexpr static uint32_t max_stack_size = 512;
             codegen& cg = codegen::get();
             std::string nm = decl->getNameAsString()+"_"+decl->getParent()->getNameAsString();
+
             if (cg.is_eosio_contract(decl, cg.contract_name)) {
                ss << "\n\n#include <eosio/datastream.hpp>\n";
                ss << "#include <eosio/name.hpp>\n";
@@ -190,8 +207,22 @@ namespace eosio { namespace cdt {
                   ss << tn << " arg" << i << "; ds >> arg" << i << ";\n";
                   i++;
                }
+
+               // Create contract object
+               ss << decl->getParent()->getQualifiedNameAsString()
+                  << " obj {eosio::name{r},eosio::name{c},ds};\n";
+
+               // Call `set_exec_type()` only for contracts dervied from `eosio::contract`.
+               // A contract class can have only `eosio::contract` attribute
+               // but does not inherit from the `eosio::contract` class;
+               // it may not have `set_exec_type()`. We need to make sure the class derives
+               // from `eosio::contract` before calling set_exec_type().
+               if (base_is_eosio_contract_class(decl)) {
+                  ss << "obj.set_exec_type(eosio::contract::exec_type_t::action);\n";
+               }
+
                const auto& call_action = [&]() {
-                  ss << decl->getParent()->getQualifiedNameAsString() << "{eosio::name{r},eosio::name{c},ds}." << decl->getNameAsString() << "(";
+                  ss << "obj." << decl->getNameAsString() << "(";
                   for (int i=0; i < decl->parameters().size(); i++) {
                      ss << "arg" << i;
                      if (i < decl->parameters().size()-1)
@@ -260,9 +291,22 @@ namespace eosio { namespace cdt {
                   ss << tn << " arg" << i << "; ds >> arg" << i << ";\n";
                   i++;
                }
+
+               // Create contract object
+               ss << decl->getParent()->getQualifiedNameAsString()
+                  << " obj {eosio::name{receiver},eosio::name{receiver},ds};\n";
+
+               // Call `set_exec_type()` only for contracts dervied from `eosio::contract`.
+               // A contract class can have only `eosio::contract` attribute
+               // but does not inherit from the `eosio::contract` class;
+               // it may not have `set_exec_type()`. We need to make sure the class derives
+               // from `eosio::contract` before calling set_exec_type().
+               if (base_is_eosio_contract_class(decl)) {
+                  ss << "obj.set_exec_type(eosio::contract::exec_type_t::call);\n";
+               }
+
                const auto& call_function = [&]() {
-                  // `true` indicates a sync call
-                  ss << decl->getParent()->getQualifiedNameAsString() << "{eosio::name{receiver},eosio::name{receiver},ds,true}." << decl->getNameAsString() << "(";
+                  ss << "obj." << decl->getNameAsString() << "(";
                   for (int i=0; i < decl->parameters().size(); i++) {
                      ss << "arg" << i;
                      if (i < decl->parameters().size()-1)


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Add `is_sync_call()` to `eosio::contract` class so users can use it together with `get_sender()` to perform basic authorization checks on sync calls (see https://github.com/AntelopeIO/cdt/issues/368 for an example).

It seems the current implementation of adding a default `is_call` argument to the constructor of `eosio::contract` is the cleanest one, except it imposes a restriction that if a new contract class contains sync calls and it provides its own constructor, the constructor's signature must match with `eosio::contract`'s, as in the example of https://github.com/AntelopeIO/cdt/commit/09b234bf35b99e84405a750de54608ae5802d2da
```cpp
class [[eosio::contract]] sync_call_addr_book_callee : public eosio::contract {
public:
   sync_call_addr_book_callee(eosio::name receiver, eosio::name code, eosio::datastream<const  char*> ds, bool is_call = false): contract(receiver, code, ds, is_call) {}
```
But this restriction seems reasonable, as it only applies to new contracts using sync calls and if only the new contracts need its own constructors. In fact, since the above example has an empty body, it is redundant and can/should be removed. In addition, existing contracts and contracts without sync calls are not affected.

An alternative is not modify the constructor of `eosio::contract`, but adding an extra method like `set_is_sync_call()` after a contract is constructed in the sync call dispatcher. This seems ugly.

Resolves https://github.com/AntelopeIO/cdt/issues/368


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
