### PR TITLE
[5.0.0-dev] Fix action wrappers and call wrappers compile failures if their first argument is bool

### DIFF
--- a/libraries/eosiolib/contracts/eosio/detail.hpp
+++ b/libraries/eosiolib/contracts/eosio/detail.hpp
@@ -46,6 +46,11 @@ namespace eosio { namespace detail {
    template <typename T>
    struct is_same<T,bool> { static constexpr bool value = std::is_integral<T>::value; };
 
+   // Full specialization to resolve ambiguity introduced by partial specializations
+   // is_same<bool,U> and is_same<T,bool>
+   template <>
+   struct is_same<bool, bool> { static constexpr bool value = true; };
+
    template <size_t N, size_t I, auto Arg, auto... Args>
    struct get_nth_impl { static constexpr auto value  = get_nth_impl<N,I+1,Args...>::value; };
 

--- a/tests/unit/test_contracts/sync_call_callee.hpp
+++ b/tests/unit/test_contracts/sync_call_callee.hpp
@@ -38,6 +38,27 @@ public:
    [[eosio::call]]
    struct1_t pass_multi_structs(struct1_t s1, int32_t m, struct2_t s2);
 
+   // The following are used to test arguments checks involving bool type.
+   [[eosio::call]]
+   bool bool_ret_no_arg() { return true; };
+   using bool_ret_no_arg_func = eosio::call_wrapper<"bool_ret_no_arg"_i, &sync_call_callee::bool_ret_no_arg>;
+
+   [[eosio::call]]
+   bool bool_ret_bool_arg(bool b) { return b; };
+   using bool_ret_bool_arg_func = eosio::call_wrapper<"bool_ret_bool_arg"_i, &sync_call_callee::bool_ret_bool_arg>;
+
+   [[eosio::call]]
+   void void_ret_bool_arg(bool b) { };
+   using void_ret_bool_arg_func = eosio::call_wrapper<"void_ret_bool_arg"_i, &sync_call_callee::void_ret_bool_arg>;
+
+   [[eosio::call]]
+   void void_ret_boolint_args(bool b, int i) { };
+   using void_ret_boolint_args_func = eosio::call_wrapper<"void_ret_boolint_args"_i, &sync_call_callee::void_ret_boolint_args>;
+
+   [[eosio::call]]
+   void void_ret_intbool_args(int i, bool b) { };
+   using void_ret_intbool_args_func = eosio::call_wrapper<"void_ret_intbool_args"_i, &sync_call_callee::void_ret_intbool_args>;
+
    using return_ten_func = eosio::call_wrapper<"return_ten"_i, &sync_call_callee::return_ten>;
    using echo_input_func = eosio::call_wrapper<"echo_input"_i, &sync_call_callee::echo_input>;
    using void_func_func = eosio::call_wrapper<"void_func"_i, &sync_call_callee::void_func>;

--- a/tests/unit/test_contracts/sync_call_caller.cpp
+++ b/tests/unit/test_contracts/sync_call_caller.cpp
@@ -172,4 +172,36 @@ public:
       status = eosio::call("callee"_n, 0, bad_version_data.data(), bad_version_data.size());
       eosio::check(status == -10000, "call did not return -10000 for invalid version");
    }
+
+   // The following tests verify type_check for arguments involving bool type.
+   // If cdt-cpp can compile the action, it indicates type_check works.
+   [[eosio::action]]
+   void boolargtest() {
+      sync_call_callee::bool_ret_no_arg_func{ "callee"_n }();
+   }
+
+   [[eosio::action]]
+   void boolargtest1() {
+      sync_call_callee::bool_ret_bool_arg_func{ "callee"_n }(true);
+   }
+
+   [[eosio::action]]
+   void boolargtest2() {
+      sync_call_callee::bool_ret_bool_arg_func{ "callee"_n }(1); // allow an integer to be passed
+   }
+
+   [[eosio::action]]
+   void boolargtest3() {
+      sync_call_callee::void_ret_bool_arg_func{ "callee"_n }(true);
+   }
+
+   [[eosio::action]]
+   void boolargtest4() {
+      sync_call_callee::void_ret_boolint_args_func{ "callee"_n }(true, 1);
+   }
+
+   [[eosio::action]]
+   void boolargtest5() {
+      sync_call_callee::void_ret_intbool_args_func{ "callee"_n }(1, true);
+   }
 };


### PR DESCRIPTION
… argument is bool

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

For a call wrapper like
```cpp
[[eosio::call]]
bool bool_ret_bool_arg(bool b) { return b; };
using bool_ret_bool_arg_func = eosio::call_wrapper<"bool_ret_bool_arg"_i, &sync_call_callee::bool_ret_bool_arg>;
```

CDT will fail the compile with

```
.../build/bin/../include/eosiolib/contracts/eosio/detail.hpp:71:29: error: ambiguous partial specializations of 'is_same<bool, bool>'
      static_assert(detail::is_same<typename convert<T>::type, typename convert<typename std::tuple_element<I, deduced<Function>>::type>::type>::value);
                            ^
.../build/bin/../include/eosiolib/contracts/eosio/detail.hpp:79:17: note: in instantiation of template class 'eosio::detail::check_types<&sync_call_callee::void_ret_bool_arg, 0, bool>' requested here
         return check_types<Function, 0, Ts...>::value;
                ^
.../build/bin/../include/eosiolib/contracts/eosio/call.hpp:115:32: note: in instantiation of function template specialization 'eosio::detail::type_check<&sync_call_callee::void_ret_bool_arg, bool>' requested here
         static_assert(detail::type_check<Func_Ref, Args...>());
                               ^
.../tests/unit/test_contracts/sync_call_caller.cpp:195:61: note: in instantiation of function template specialization 'eosio::call_wrapper<15588028823843593861, &sync_call_callee::void_ret_bool_arg, eosio::access_mode::read_write, eosio::support_mode::abort_op>::operator()<bool>' requested here
      sync_call_callee::void_ret_bool_arg_func{ "callee"_n }(true);
                                                            ^
.../build/bin/../include/eosiolib/contracts/eosio/detail.hpp:44:11: note: partial specialization matches [with U = bool]
   struct is_same<bool,U> { static constexpr bool value = std::is_integral<U>::value; };
          ^
.../build/bin/../include/eosiolib/contracts/eosio/detail.hpp:47:11: note: partial specialization matches [with T = bool]
   struct is_same<T,bool> { static constexpr bool value = std::is_integral<T>::value; };
```

The problem is due to partial specialization for bool type.

Resolves https://github.com/AntelopeIO/cdt/issues/370

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
