### PR TITLE
[4.1.0] Fix action_wrapper failure if its first argument is a bool

### DIFF
--- a/libraries/eosiolib/contracts/eosio/action.hpp
+++ b/libraries/eosiolib/contracts/eosio/action.hpp
@@ -455,6 +455,11 @@ namespace eosio {
       template <typename T>
       struct is_same<T,bool> { static constexpr bool value = std::is_integral<T>::value; };
 
+      // Full specialization to resolve ambiguity introduced by partial specializations
+      // of is_same<bool,U> and is_same<T,bool>
+      template <>
+      struct is_same<bool, bool> { static constexpr bool value = true; };
+
       template <size_t N, size_t I, auto Arg, auto... Args>
       struct get_nth_impl { static constexpr auto value  = get_nth_impl<N,I+1,Args...>::value; };
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

As discussed in the standup, we will fix this in `release/4.1.0` first, merge to `main`, and finally merge or cherry pick to a newly created `5.0.0-dev1` if appropriate such that developers can experience latest bug fixes. `5.0.0-dev1` is temporary in nature and will only contain non-protocol-related bug fixes and the branch will never be merged back to `main`. Any new development/bug fixes will be on `main`, and cherry pick bug fixes to `5.0.0.-dev1`.

If an action wrapper's first argument is a bool, cdt-cpp will fail, as in example

```
.../build/bin/../include/eosiolib/contracts/eosio/detail.hpp:65:29: error: ambiguous partial specializations of 'is_same<bool, bool>'
      static_assert(detail::is_same<typename convert<T>::type, typename convert<typename std::tuple_element<I, deduced<Function>>::type>::type>::value);
                            ^
.../build/bin/../include/eosiolib/contracts/eosio/detail.hpp:79:17: note: in instantiation of template class 'eosio::detail::check_types<&tester::test, 0, bool, eosio::name &, std::__1::basic_string<char> &>' requested here
         return check_types<Function, 0, Ts...>::value;
                ^
.../build/bin/../include/eosiolib/contracts/eosio/../../contracts/eosio/action.hpp:459:32: note: in instantiation of function template specialization 'eosio::detail::type_check<&tester::test, bool, eosio::name &, std::__1::basic_string<char> &>' requested here
         static_assert(detail::type_check<Action, Args...>());
                               ^
.../build/bin/../include/eosiolib/contracts/eosio/../../contracts/eosio/action.hpp:464:10: note: in instantiation of function template specialization 'eosio::action_wrapper<4986958682836172800, &tester::test>::to_action<bool, eosio::name &, std::__1::basic_string<char> &>' requested here
         to_action(std::forward<Args>(args)...).send();
```

Resolves https://github.com/AntelopeIO/cdt/issues/370

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
