### PR TITLE
[4.1.1] fix compile on recent clang versions

### DIFF
--- a/tools/jsoncons/include/jsoncons/json_type_traits.hpp
+++ b/tools/jsoncons/include/jsoncons/json_type_traits.hpp
@@ -170,7 +170,6 @@ public:
     {
         using std::swap;
         swap(lhs.it_,rhs.it_);
-        swap(lhs.empty_,rhs.empty_);
     }
 
 private:
@@ -248,7 +247,6 @@ public:
     {
         using std::swap;
         swap(lhs.it_,rhs.it_);
-        swap(lhs.empty_,rhs.empty_);
     }
 
 private:


### PR DESCRIPTION
On recent clang versions (certainly clang20 which I used for making this fix, but possibly 18 or 19 too, and certainly modern Xcodes as reported from community), cdt fails to compile due to something wonky in the ancient version of jsoncons where it is referring to an `empty_` here that just doesn't exist :woman_shrugging: I mean look..
https://github.com/AntelopeIO/cdt/blob/d658c90b6dec7614fb57458c55bdbff28ef1425e/tools/jsoncons/include/jsoncons/json_type_traits.hpp#L175-L177
no `empty_` there. I think the code is just buggy and newer versions of clang stumble on it.

I didn't even venture to try and update the library.

Considering it for stable because it has been reported in community.